### PR TITLE
Begin documenting the Elixir API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ _deps
 _plugins
 _tdeps
 deps
+doc
 logs
 test/ct.cover.spec
 /_build

--- a/lib/jose.ex
+++ b/lib/jose.ex
@@ -1,9 +1,39 @@
 defmodule JOSE do
 
+  @moduledoc """
+  JOSE stands for JSON Object Signing and Encryption. It is a set of standards 
+  specified by the IETF. The oficial specifications are described below:
+
+  - JWS (Json Web Signature)  : [RFC7515](https://tools.ietf.org/html/rfc7515)
+  - JWE (Json Web Encryption) : [RFC7516](https://tools.ietf.org/html/rfc7516)
+  - JWK (Json Web Key)        : [RFC7517](https://tools.ietf.org/html/rfc7517)
+  - JWA (Json Web Algorithms) : [RFC7518](https://tools.ietf.org/html/rfc7518)
+  - JWT (Json Web Token)      : [RFC7519](https://tools.ietf.org/html/rfc7519)
+
+  This module is the main entry point for decoding/encoding a JWT.
+  """
+  
   # API
+  @doc """
+  Decodes a JWT in binary form into a map of claims.
+  """
   def decode(binary), do: :jose.decode(binary)
+
+  @doc """
+  Encodes a given JOSE term into a binary representation.
+  """
   def encode(term), do: :jose.encode(term)
+
+  @doc """
+  Retrieves the current set JSON module. 
+  """
   def json_module(), do: :jose.json_module()
+
+  
+  @doc """
+  Sets the JSON module used for JSON encoding/decoding. Currently 
+  supports Poison and JSX.
+  """
   def json_module(module), do: :jose.json_module(module)
 
 end

--- a/lib/jose/jwk.ex
+++ b/lib/jose/jwk.ex
@@ -1,6 +1,16 @@
 require Record
 
 defmodule JOSE.JWK do
+
+  @moduledoc """
+  JWK stands for Json Web Key. This module parses the record definition in 
+  `:jose_jwk` and eases the transition between Erlang/Elixir.
+
+  It provides several utilities for creating/decoding key structs from files, 
+  pem representation, binary and etc. It also provides mechanisms for signing 
+  and verifying data.
+  """
+
   record = Record.extract(:jose_jwk, from_lib: "jose/include/jose_jwk.hrl")
   keys   = :lists.map(&elem(&1, 0), record)
   vals   = :lists.map(&{&1, [], nil}, keys)
@@ -35,9 +45,25 @@ defmodule JOSE.JWK do
   def from_file(password, file), do: :jose_jwk.from_file(password, file) |> from_encrypted_record
   def from_map(map), do: :jose_jwk.from_map(map) |> from_record
   def from_map(password, map), do: :jose_jwk.from_map(password, map) |> from_encrypted_record
+
+  @doc """
+  Generates a key from a pem representation (Privacy Enhanced Email) in binary.
+  """
   def from_pem(pem), do: :jose_jwk.from_pem(pem) |> from_record
+
+  @doc """
+  Same as `from_pem/1` but with a password used to unlock it. 
+  """
   def from_pem(password, pem), do: :jose_jwk.from_pem(password, pem) |> from_record
+
+  @doc """
+  Generates a key from reading a pem representation from a file.
+  """
   def from_pem_file(file), do: :jose_jwk.from_pem_file(file) |> from_record
+
+  @doc """
+  Same as `from_pem_file/1` but with a password to unlock it.
+  """
   def from_pem_file(password, file), do: :jose_jwk.from_pem_file(password, file) |> from_record
 
   defp from_encrypted_record({jwe, jwk}) when is_tuple(jwe) and is_tuple(jwk) do

--- a/lib/jose/jws.ex
+++ b/lib/jose/jws.ex
@@ -1,6 +1,7 @@
 require Record
 
 defmodule JOSE.JWS do
+
   record = Record.extract(:jose_jws, from_lib: "jose/include/jose_jws.hrl")
   keys   = :lists.map(&elem(&1, 0), record)
   vals   = :lists.map(&{&1, [], nil}, keys)

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule JOSE.Mixfile do
      source_url: "https://github.com/potatosalad/erlang-jose",
      docs: fn ->
        {ref, 0} = System.cmd("git", ["rev-parse", "--verify", "--quiet", "HEAD"])
-       [source_ref: ref, main: "README", readme: "README.md"]
+       [source_ref: ref, readme: "README.md"]
      end,
      description: description,
      package: package]
@@ -26,7 +26,9 @@ defmodule JOSE.Mixfile do
   defp deps do
     [{:base64url, "~> 0.0.1"},
      {:jsx, "~> 2.0", only: [:dev, :test]},
-     {:poison, "~> 1.4", only: [:dev, :test]}]
+     {:poison, "~> 1.4", only: [:dev, :test]},
+     {:ex_doc, "~> 0.9", only: :docs},
+     {:earmark, "~> 0.1", only: :docs}]
   end
 
   defp description do
@@ -47,6 +49,7 @@ defmodule JOSE.Mixfile do
        "src"
      ],
      licenses: ["Mozilla Public License Version 2.0"],
-     links: %{"Github" => "https://github.com/potatosalad/erlang-jose"}]
+     links: %{"Github" => "https://github.com/potatosalad/erlang-jose",
+             "Docs" => "https://hexdocs.pm/erlang-jose"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,5 @@
+%{"base64url": {:hex, :base64url, "0.0.1"},
+  "earmark": {:hex, :earmark, "0.1.17"},
+  "ex_doc": {:hex, :ex_doc, "0.9.0"},
+  "jsx": {:hex, :jsx, "2.7.1"},
+  "poison": {:hex, :poison, "1.5.0"}}


### PR DESCRIPTION
This is an initial attempt at documenting the Elixir API of the erlang-jose library. I still have to find more time to dig in deeper on the API to understand its structures.

Although incomplete, this has the base for publishing it to hex and linking the docs to the version. If you run:

```elixir
MIX_ENV=docs mix do deps.get, compile
MIX_ENV=docs mix docs
```

You will see something like:
![screenshot from 2015-09-15 23 44 23](https://cloud.githubusercontent.com/assets/7049728/9895241/b876846a-5c03-11e5-9513-2c9257d1ba83.png)

After that is just a matter of issuing:

```elixir
MIX_ENV=docs mix hex.docs
```

And Hex will show a "(docs)" link. 

@potatosalad What do you think of starting small? This might be helpful in a future version release where people will get more insightful messages from `h JOSE.JWK.verify` in the shell or IDEs. 