### PR TITLE
Add missing guards in jose_jws:sign/4

### DIFF
--- a/src/jose_jws.erl
+++ b/src/jose_jws.erl
@@ -234,7 +234,9 @@ sign(Key, PlainText, Header, JWS=#jose_jws{alg={ALGModule, ALG}})
 	Signature = base64url:encode(ALGModule:sign(Key, SigningInput, ALG)),
 	{Modules, maps:put(<<"payload">>, Payload,
 		signature_to_map(Protected, Header, Key, Signature))};
-sign(Key, PlainText, Header, Other) ->
+sign(Key, PlainText, Header, Other)
+		when is_binary(PlainText)
+		andalso is_map(Header) ->
 	sign(Key, PlainText, Header, from(Other)).
 
 %% See https://tools.ietf.org/html/draft-ietf-jose-jws-signing-input-options-04


### PR DESCRIPTION
Invoke `jose_jws:sign/4` with non binary payload (e.g. `jose_jws:sign(Key, #{}, #{}, Other)`) causes infinite loop.