### PR TITLE
Added Elixir versions to travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 
 elixir:
   - 1.0.5
+  - 1.1.1
+  - 1.2.0
 
 otp_release:
   - 17.5
@@ -16,3 +18,8 @@ notifications:
 after_script:
   - "rm -rf _build deps ebin"
   - "make tests"
+
+matrix:
+  exclude:
+    - otp_release: 17.5
+      elixir: 1.2.0


### PR DESCRIPTION
This adds Elixir version 1.1 and 1.2 in travis. Because 1.2 depends only on Erlang 18, there is also a matrix config to exclude it form running in Erlang 17.

In my fork, the build failed because running the test suite in Erlang 17.5 takes more than 10 minutes without output. This makes Travis to abort the build. Perhaps some output in the tests may satisfy Travis.