### PR TITLE
Replace all instances of rand_bytes with strong_rand_bytes

### DIFF
--- a/src/jose_jwa_pkcs1.erl
+++ b/src/jose_jwa_pkcs1.erl
@@ -264,7 +264,7 @@ eme_pkcs1_encode(DM, K)
 				<< (crypto:rand_uniform(1, 256)) >>;
 			_ ->
 				<< C >>
-		end)/binary >> || << C >> <= crypto:rand_bytes(PSLen)
+		end)/binary >> || << C >> <= crypto:strong_rand_bytes(PSLen)
 	>>,
 	EM = << 16#00, 16#02, PS/binary, 16#00, DM/binary >>,
 	{ok, EM}.
@@ -413,7 +413,7 @@ emsa_pss_encode(Hash, Message, -1, EMBits)
 emsa_pss_encode(Hash, Message, SaltLen, EMBits)
 		when is_integer(SaltLen)
 		andalso SaltLen >= 0 ->
-	Salt = crypto:rand_bytes(SaltLen),
+	Salt = crypto:strong_rand_bytes(SaltLen),
 	emsa_pss_encode(Hash, Message, Salt, EMBits);
 emsa_pss_encode(Hash, Message, Salt, EMBits)
 		when is_tuple(Hash)
@@ -602,7 +602,7 @@ rsaes_oaep_encrypt(Hash, PlainText, Label, RSAPublicKey=#'RSAPublicKey'{})
 		andalso is_binary(PlainText)
 		andalso is_binary(Label) ->
 	HLen = byte_size(Hash(<<>>)),
-	Seed = crypto:rand_bytes(HLen),
+	Seed = crypto:strong_rand_bytes(HLen),
 	rsaes_oaep_encrypt(Hash, PlainText, Label, Seed, RSAPublicKey);
 rsaes_oaep_encrypt(Hash, PlainText, Label, RSAPublicKey)
 		when is_tuple(Hash)

--- a/src/jose_jwe_alg_aes_kw.erl
+++ b/src/jose_jwe_alg_aes_kw.erl
@@ -104,7 +104,7 @@ key_encrypt(DerivedKey, DecryptedKey, JWEAESKW=#jose_jwe_alg_aes_kw{bits=Bits, g
 	{CipherText, CipherTag} = jose_jwa:block_encrypt({aes_gcm, Bits}, DerivedKey, IV, {<<>>, DecryptedKey}),
 	{CipherText, JWEAESKW#jose_jwe_alg_aes_kw{ tag = CipherTag }};
 key_encrypt(DerivedKey, DecryptedKey, JWEAESKW=#jose_jwe_alg_aes_kw{gcm=true, iv=undefined}) ->
-	key_encrypt(DerivedKey, DecryptedKey, JWEAESKW#jose_jwe_alg_aes_kw{ iv = crypto:rand_bytes(12) });
+	key_encrypt(DerivedKey, DecryptedKey, JWEAESKW#jose_jwe_alg_aes_kw{ iv = crypto:strong_rand_bytes(12) });
 key_encrypt(#jose_jwk{kty={KTYModule, KTY}}, DecryptedKey, JWEAESKW=#jose_jwe_alg_aes_kw{}) ->
 	key_encrypt(KTYModule:derive_key(KTY), DecryptedKey, JWEAESKW).
 

--- a/src/jose_jwe_alg_pbes2.erl
+++ b/src/jose_jwe_alg_pbes2.erl
@@ -74,7 +74,7 @@ key_decrypt(#jose_jwk{kty={KTYModule, KTY}}, EncryptedKey, JWEPBES2=#jose_jwe_al
 	key_decrypt(KTYModule:derive_key(KTY), EncryptedKey, JWEPBES2).
 
 key_encrypt(Password, DecryptedKey, ALG0=#jose_jwe_alg_pbes2{bits=Bits, salt=undefined}) ->
-	ALG1 = ALG0#jose_jwe_alg_pbes2{salt=wrap_salt(crypto:rand_bytes(Bits div 8), ALG0)},
+	ALG1 = ALG0#jose_jwe_alg_pbes2{salt=wrap_salt(crypto:strong_rand_bytes(Bits div 8), ALG0)},
 	key_encrypt(Password, DecryptedKey, ALG1);
 key_encrypt(Password, DecryptedKey, ALG0=#jose_jwe_alg_pbes2{bits=Bits, iter=undefined}) ->
 	ALG1 = ALG0#jose_jwe_alg_pbes2{iter=(Bits * 32)},

--- a/src/jose_jwe_enc_aes.erl
+++ b/src/jose_jwe_enc_aes.erl
@@ -195,10 +195,10 @@ block_encrypt({AAD, PlainText}, CEK, IV, #jose_jwe_enc_aes{
 	{CipherText, CipherTag}.
 
 next_cek(#jose_jwe_enc_aes{cek_len=CEKLen}) ->
-	crypto:rand_bytes(CEKLen).
+	crypto:strong_rand_bytes(CEKLen).
 
 next_iv(#jose_jwe_enc_aes{iv_len=IVLen}) ->
-	crypto:rand_bytes(IVLen).
+	crypto:strong_rand_bytes(IVLen).
 
 %%====================================================================
 %% API functions

--- a/src/jose_jwk_kty.erl
+++ b/src/jose_jwk_kty.erl
@@ -139,7 +139,7 @@ key_encryptor(_KTY, _Fields, Key) when is_binary(Key) ->
 			true  -> <<"A128GCM">>
 		end,
 		<<"p2c">> => 4096,
-		<<"p2s">> => base64url:encode(crypto:rand_bytes(16))
+		<<"p2s">> => base64url:encode(crypto:strong_rand_bytes(16))
 	}.
 
 %%%-------------------------------------------------------------------

--- a/src/jose_jwk_kty_oct.erl
+++ b/src/jose_jwk_kty_oct.erl
@@ -66,7 +66,7 @@ to_thumbprint_map(K, F) ->
 %%====================================================================
 
 generate_key(Size) when is_integer(Size) ->
-	{crypto:rand_bytes(Size), #{}};
+	{crypto:strong_rand_bytes(Size), #{}};
 generate_key({oct, Size}) when is_integer(Size) ->
 	generate_key(Size).
 

--- a/src/jose_jwk_pem.erl
+++ b/src/jose_jwk_pem.erl
@@ -37,7 +37,7 @@ from_binary(Password, EncryptedPEMBinary) when is_binary(EncryptedPEMBinary) ->
 	end.
 
 to_binary(Password, KeyType, Key) ->
-	CipherInfo = {"DES-EDE3-CBC", crypto:rand_bytes(8)},
+	CipherInfo = {"DES-EDE3-CBC", crypto:strong_rand_bytes(8)},
 	PasswordString = binary_to_list(iolist_to_binary(Password)),
 	PEMEntry = public_key:pem_entry_encode(KeyType, Key, {CipherInfo, PasswordString}),
 	public_key:pem_encode([PEMEntry]).


### PR DESCRIPTION
Elixir 1.3 treats all warnings as errors, Erlang OTP 19.0 throws deprecation warnings for `crypto:rand_bytes`. Replaced each call with `strong_rand_bytes` instead.