### PR TITLE
add parentheses to remove the ambiguity on Elixir 1.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,10 +5,10 @@ defmodule JOSE.Mixfile do
     [app: :jose,
      version: "1.8.0",
      elixir: "~> 1.0",
-     erlc_options: erlc_options,
+     erlc_options: erlc_options(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
+     deps: deps(),
      name: "JOSE",
      source_url: "https://github.com/potatosalad/erlang-jose",
      docs: fn ->
@@ -16,8 +16,8 @@ defmodule JOSE.Mixfile do
        [source_ref: ref, main: "JOSE", extras: ["README.md", "CHANGELOG.md",
         "examples/KEY-GENERATION.md", "ALGORITHMS.md"]]
      end,
-     description: description,
-     package: package]
+     description: description(),
+     package: package()]
   end
 
   def application do


### PR DESCRIPTION
When using Elixir 1.4 new warnings are raised:
```
warning: variable "erlc_options" does not exist and is being expanded to "erlc_options()", please use parentheses to remove the ambiguity or change the variable name
  /home/alexandrubagu/devel/antidote/deps/jose/mix.exs:8

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /home/alexandrubagu/devel/antidote/deps/jose/mix.exs:11

warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  /home/alexandrubagu/devel/antidote/deps/jose/mix.exs:19

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /home/alexandrubagu/devel/antidote/deps/jose/mix.exs:20
```