### PR TITLE
Fix rebar platform_define regex to exclude OTP <18

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,8 @@
 %% -*- mode: erlang; tab-width: 4; indent-tabs-mode: 1; st-rulers: [70] -*-
 %% vim: ts=4 sw=4 ft=erlang noet
 {erl_opts, [
-	{platform_define, "(?=^[0-9]+)(?!^17$)", optional_callbacks},
+	% this platform define is no longer necessary once OTP <=17 support is removed
+	{platform_define, "^(18|19|2)", optional_callbacks},
 	debug_info,
 	warnings_as_errors
 ]}.


### PR DESCRIPTION
@potatosalad 

The regex in `rebar.config` to exclude OTP 17 from defining these optional callbacks was not working. The new one explicitly matches OTP 18, 19, or 20+ versions.

Tested on OTP 17 and 20.

Fixes issues:
https://github.com/potatosalad/erlang-jose/issues/16
https://github.com/potatosalad/erlang-jose/issues/29