### PR TITLE
Added a fix incompatible OTP 21 build

### DIFF
--- a/src/jose_public_key.erl
+++ b/src/jose_public_key.erl
@@ -12,6 +12,10 @@
 
 -include("jose_public_key.hrl").
 
+-ifdef(OTP_RELEASE).
+-compile({nowarn_deprecated_function, [{erlang, get_stacktrace, 0}]}).
+-endif.
+
 %% API
 -export([der_decode/2]).
 -export([der_encode/2]).


### PR DESCRIPTION
To fix issue with OTP 21 when building with eep-0047 causing a build warn in OTP-21. 
