### PR TITLE
Add macro to compile without warnings due to new stacktrace syntax.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.8.5 (2018-11-19)
+
+* Enhancements
+  * Add macro so the application compiles without warnings after erlang:get_stacktrace/0 has been deprecated.
+
 ## 1.8.4 (2017-05-18)
 
 * Enhancements

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = jose
 PROJECT_DESCRIPTION = JSON Object Signing and Encryption (JOSE) for Erlang and Elixir.
-PROJECT_VERSION = 1.8.4
+PROJECT_VERSION = 1.8.5
 
 DEPS = base64url
 

--- a/include/exception.hrl
+++ b/include/exception.hrl
@@ -1,0 +1,7 @@
+-ifdef(OTP_RELEASE). %% this implies 21 or higher
+-define(EXCEPTION(Class, Reason, Stacktrace), Class:Reason:Stacktrace).
+-define(GET_STACK(Stacktrace), Stacktrace).
+-else.
+-define(EXCEPTION(Class, Reason, _), Class:Reason).
+-define(GET_STACK(_), erlang:get_stacktrace()).
+-endif.

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule JOSE.Mixfile do
 
   def project do
     [app: :jose,
-     version: "1.8.4",
+     version: "1.8.5",
      elixir: "~> 1.0",
      erlc_options: erlc_options(),
      build_embedded: Mix.env == :prod,

--- a/src/jose.app.src
+++ b/src/jose.app.src
@@ -2,7 +2,7 @@
 %% vim: ts=4 sw=4 ft=erlang noet
 {application, jose, [
 	{description, "JSON Object Signing and Encryption (JOSE) for Erlang and Elixir."},
-	{vsn, "1.8.4"},
+	{vsn, "1.8.5"},
 	{id, "git"},
 	{mod, {'jose_app', []}},
 	{registered, []},

--- a/src/jose_public_key.erl
+++ b/src/jose_public_key.erl
@@ -10,6 +10,7 @@
 %%%-------------------------------------------------------------------
 -module(jose_public_key).
 
+-include("exception.hrl").
 -include("jose_public_key.hrl").
 
 %% API
@@ -40,13 +41,12 @@ pem_encode(PEMEntries) when is_list(PEMEntries) ->
 	try
 		public_key:pem_encode(PEMEntries)
 	catch
-		Class:Reason ->
-			ST = erlang:get_stacktrace(),
+		?EXCEPTION(Class, Reason, ST) ->
 			case pem_enc(PEMEntries) of
 				{true, PEMBinary} ->
 					PEMBinary;
 				false ->
-					erlang:raise(Class, Reason, ST)
+					erlang:raise(Class, Reason, ?GET_STACK(ST))
 			end
 	end.
 
@@ -56,13 +56,12 @@ pem_entry_decode(PEMEntry) ->
 		try
 			public_key:pem_entry_decode(PEMEntry)
 		catch
-			Class:Reason ->
-				ST = erlang:get_stacktrace(),
+    		?EXCEPTION(Class, Reason, ST) ->
 				case pem_entry_dec(PEMEntry) of
 					{true, DecodedPEMEntry} ->
 						DecodedPEMEntry;
 					false ->
-						erlang:raise(Class, Reason, ST)
+						erlang:raise(Class, Reason, ?GET_STACK(ST))
 				end
 		end,
 	case Result of
@@ -80,13 +79,12 @@ pem_entry_decode(PEMEntry, Password) ->
 		try
 			public_key:pem_entry_decode(PEMEntry, Password)
 		catch
-			Class:Reason ->
-				ST = erlang:get_stacktrace(),
+    		?EXCEPTION(Class, Reason, ST) ->
 				case pem_entry_dec(PEMEntry) of
 					{true, DecodedPEMEntry} ->
 						DecodedPEMEntry;
 					false ->
-						erlang:raise(Class, Reason, ST)
+						erlang:raise(Class, Reason, ?GET_STACK(ST))
 				end
 		end,
 	case Result of
@@ -103,13 +101,12 @@ pem_entry_encode(ASN1Type, Entity) ->
 	try
 		public_key:pem_entry_encode(ASN1Type, Entity)
 	catch
-		Class:Reason ->
-			ST = erlang:get_stacktrace(),
+		?EXCEPTION(Class, Reason, ST) ->
 			case pem_entry_enc(ASN1Type, Entity) of
 				{true, PEMEntry} ->
 					PEMEntry;
 				false ->
-					erlang:raise(Class, Reason, ST)
+					erlang:raise(Class, Reason, ?GET_STACK(ST))
 			end
 	end.
 
@@ -118,13 +115,12 @@ pem_entry_encode(ASN1Type, Entity, Password) ->
 	try
 		public_key:pem_entry_encode(ASN1Type, Entity, Password)
 	catch
-		Class:Reason ->
-			ST = erlang:get_stacktrace(),
+		?EXCEPTION(Class, Reason, ST) ->
 			case pem_entry_enc(ASN1Type, Entity, Password) of
 				{true, PEMEntry} ->
 					PEMEntry;
 				false ->
-					erlang:raise(Class, Reason, ST)
+					erlang:raise(Class, Reason, ?GET_STACK(ST))
 			end
 	end.
 
@@ -230,13 +226,12 @@ pem_entry_enc0(ASN1Type, Entry, Cipher) ->
 	try
 		public_key:pem_entry_encode(ASN1Type, Entry, Cipher)
 	catch
-		Class:Reason ->
-			ST = erlang:get_stacktrace(),
+	    ?EXCEPTION(Class, Reason, ST) ->
 			case pem_entry_enc1(ASN1Type, Entry, Cipher) of
 				{true, Encoded} ->
 					Encoded;
 				false ->
-					erlang:raise(Class, Reason, ST)
+					erlang:raise(Class, Reason, ?GET_STACK(ST))
 			end
 	end.
 


### PR DESCRIPTION
Macro to compile without warnings both before R21 and after.