### PR TITLE
2019-02-19_fix-pss-saltlen

### DIFF
--- a/lib/jose/jwa.ex
+++ b/lib/jose/jwa.ex
@@ -101,7 +101,7 @@ defmodule JOSE.JWA do
   ## Options
 
     * `:rsa_padding` - one of `:rsa_pkcs1_pss_padding` or `:rsa_pkcs1_padding`
-    * `:rsa_pss_saltlen` - sets the salt length for `:rsa_pkcs1_pss_padding`, defaults to `-2`
+    * `:rsa_pss_saltlen` - sets the salt length for `:rsa_pkcs1_pss_padding`, defaults to `-1`
       * `-2` - use maximum for salt length
       * `-1` - use hash length for salt length
       * any number higher than `-1` is used as the actual salt length
@@ -115,7 +115,7 @@ defmodule JOSE.JWA do
 
     * `:rsa_padding` - one of `:rsa_pkcs1_pss_padding` or `:rsa_pkcs1_padding`
     * `:rsa_pss_saltlen` - sets the salt length for `:rsa_pkcs1_pss_padding`, defaults to `-2`
-      * `-2` - use maximum for salt length
+      * `-2` - automatically determine based on the PSS block structure
       * `-1` - use hash length for salt length
       * any number higher than `-1` is used as the actual salt length
   """

--- a/src/jose_jwa_pkcs1.erl
+++ b/src/jose_jwa_pkcs1.erl
@@ -96,7 +96,7 @@ sign(Message, DigestType, RSAPrivateKey=#'RSAPrivateKey'{}, Options)
 		when is_list(Options) ->
 	Res = case proplists:get_value(rsa_padding, Options) of
 		rsa_pkcs1_pss_padding ->
-			SaltLen = proplists:get_value(rsa_pss_saltlen, Options, -2),
+			SaltLen = proplists:get_value(rsa_pss_saltlen, Options, -1),
 			rsassa_pss_sign(DigestType, Message, SaltLen, RSAPrivateKey);
 		rsa_pkcs1_padding ->
 			rsassa_pkcs1_sign(DigestType, Message, RSAPrivateKey);


### PR DESCRIPTION
### Changes
- use -1 instead of -2 for sign according to RFC7518
- update docs according to RFC7518 and pkeyutl/evp_pkey_ctrl_str

### Notes
I was looking at the RFC here:
- https://tools.ietf.org/html/rfc7518#section-3.5

This line in section 3.5:
> The size of the salt value is the same size as
   the hash function output.

The issue was discovered trying to pass values between this library and an equivalent Python library. I don't think this should cause any backward compatibility problems because we only change to use `-1` for creating the signature but `-2` is still used to verify the signature which should work for the max-length and for the hash-length formats.