### PR TITLE
Use extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule JOSE.Mixfile do
     [
       app: :jose,
       version: "1.10.1",
-      elixir: "~> 1.0",
+      elixir: "~> 1.4",
       erlc_options: erlc_options(),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
@@ -22,7 +22,7 @@ defmodule JOSE.Mixfile do
   end
 
   def application() do
-    [mod: {:jose_app, []}, applications: [:crypto, :asn1, :public_key]]
+    [mod: {:jose_app, []}, extra_applications: [:crypto, :asn1, :public_key]]
   end
 
   defp deps() do


### PR DESCRIPTION
## Motivation

I'm getting the following warning when compiling jose with elixir 1.11.
```
warning: Poison.EncodeError.exception/1 defined in application :poison is used by the current application but the current application does not directly depend on :poison. To
fix this, you must do one of:

  1. If :poison is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :poison is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :poison, you may optionally skip this warning by adding [xref: [exclude: Poison.EncodeError]] to your "def project" in mix.exs

  lib/jose/poison/lexical_encoder.ex:8: JOSE.Poison.LexicalEncodeError.exception/1
```

## Proposed solution

Use extra_applications, so elixir can infer the included applications based on the dependencies.
As far as I understand this was introduced on elixir 1.4. 