### PR TITLE
fix: OTP crypto detection

### DIFF
--- a/src/jose_crypto_compat.erl
+++ b/src/jose_crypto_compat.erl
@@ -31,6 +31,10 @@ crypto_init(Cipher, Key, IV, FlagOrOptions) ->
 crypto_one_time(Cipher, Key, Data, FlagOrOptions) ->
     crypto:crypto_one_time(Cipher, Key, Data, FlagOrOptions).
 
+crypto_one_time(Cipher, Key, IV, {AAD, PlainText}, FlagOrOptions) ->
+	crypto:crypto_one_time_aead(Cipher, Key, IV, PlainText, AAD, FlagOrOptions);
+crypto_one_time(Cipher, Key, IV, {AAD, PlainText, TagOrTagLength}, FlagOrOptions) ->
+	crypto:crypto_one_time_aead(Cipher, Key, IV, PlainText, AAD, TagOrTagLength, FlagOrOptions);
 crypto_one_time(Cipher, Key, IV, Data, FlagOrOptions) ->
     crypto:crypto_one_time(Cipher, Key, IV, Data, FlagOrOptions).
 

--- a/src/jose_server.erl
+++ b/src/jose_server.erl
@@ -651,7 +651,13 @@ has_cipher(aes_cbc, KeySize) ->
 has_cipher(aes_ecb, KeySize) ->
 	Key = << 0:KeySize >>,
 	PlainText = jose_jwa_pkcs7:pad(<<>>),
-	has_block_cipher(aes_ecb, {Key, PlainText});
+	case has_block_cipher(aes_ecb, {Key, PlainText}) of
+		false ->
+			Cipher = list_to_atom("aes_" ++ integer_to_list(KeySize) ++ "_ecb"),
+			has_block_cipher(Cipher, {Key, PlainText});
+		Other ->
+			Other
+	end;
 has_cipher(aes_gcm, KeySize) ->
 	Key = << 0:KeySize >>,
 	IV = << 0:96 >>,


### PR DESCRIPTION
The new crypto API distinguishes between ciphers with no IV, with only IV but not AAD and with AAD. This fix makes it so that detecting algorithms AND using them should be working again.

Also, fixed aes_xxx_ecb detection. 

Fixes #104 