### PR TITLE
Fix AES GCM bugs on OTP 23

### DIFF
--- a/src/jose_crypto_compat.erl
+++ b/src/jose_crypto_compat.erl
@@ -31,6 +31,10 @@ crypto_init(Cipher, Key, IV, FlagOrOptions) ->
 crypto_one_time(Cipher, Key, Data, FlagOrOptions) ->
     crypto:crypto_one_time(Cipher, Key, Data, FlagOrOptions).
 
+crypto_one_time(Cipher, Key, IV, {AAD, PlainText}, FlagOrOptions) ->
+	crypto:crypto_one_time_aead(Cipher, Key, IV, PlainText, AAD, FlagOrOptions);
+crypto_one_time(Cipher, Key, IV, {AAD, PlainText, TagOrTagLength}, FlagOrOptions) ->
+	crypto:crypto_one_time_aead(Cipher, Key, IV, PlainText, AAD, TagOrTagLength, FlagOrOptions);
 crypto_one_time(Cipher, Key, IV, Data, FlagOrOptions) ->
     crypto:crypto_one_time(Cipher, Key, IV, Data, FlagOrOptions).
 

--- a/src/jose_server.erl
+++ b/src/jose_server.erl
@@ -651,7 +651,13 @@ has_cipher(aes_cbc, KeySize) ->
 has_cipher(aes_ecb, KeySize) ->
 	Key = << 0:KeySize >>,
 	PlainText = jose_jwa_pkcs7:pad(<<>>),
-	has_block_cipher(aes_ecb, {Key, PlainText});
+	case has_block_cipher(aes_ecb, {Key, PlainText}) of
+		false ->
+			Cipher = list_to_atom("aes_" ++ integer_to_list(KeySize) ++ "_ecb"),
+			has_block_cipher(Cipher, {Key, PlainText});
+		Other ->
+			Other
+	end;
 has_cipher(aes_gcm, KeySize) ->
 	Key = << 0:KeySize >>,
 	IV = << 0:96 >>,

--- a/src/jwa/jose_jwa_aes.erl
+++ b/src/jwa/jose_jwa_aes.erl
@@ -372,7 +372,9 @@ gcm_block_decrypt(H, K, IV, A, C, T) ->
 		_ ->
 			gcm_ghash(H, <<>>, IV)
 	end,
-	S0 = jose_crypto_compat:crypto_init(aes_ctr, K, Y0, true),
+	KeyLen = bit_size(K),
+	Cipher = list_to_atom("aes_" ++ integer_to_list(KeyLen) ++ "_ctr"),
+	S0 = jose_crypto_compat:crypto_init(Cipher, K, Y0, true),
 	{S1, EKY0xor} = jose_crypto_compat:crypto_update_encrypt(S0, Y0),
 	EKY0 = crypto:exor(EKY0xor, Y0),
 	<< Y0int:128/unsigned-big-integer-unit:1 >> = Y0,
@@ -396,7 +398,9 @@ gcm_block_encrypt(H, K, IV, A, P) ->
 		_ ->
 			gcm_ghash(H, <<>>, IV)
 	end,
-	S0 = jose_crypto_compat:crypto_init(aes_ctr, K, Y0, true),
+	KeyLen = bit_size(K),
+	Cipher = list_to_atom("aes_" ++ integer_to_list(KeyLen) ++ "_ctr"),
+	S0 = jose_crypto_compat:crypto_init(Cipher, K, Y0, true),
 	{S1, EKY0xor} = jose_crypto_compat:crypto_update_encrypt(S0, Y0),
 	EKY0 = crypto:exor(EKY0xor, Y0),
 	<< Y0int:128/unsigned-big-integer-unit:1 >> = Y0,


### PR DESCRIPTION
This builds off of PR #105 which should be merged first.

Fixes #103 which accounted for 7 CT failures. (#105 fixes the 11 other CT failures present in this library version 1.11.0.)  
So there should be zero failures on OTP 23 after merging these two PRs.