### PR TITLE
Update base64url dependency syntax and version to work with rebar2 and rebar3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,5 +5,5 @@
 	warnings_as_errors
 ]}.
 {deps, [
-	{base64url, "0.0.1", {pkg, base64url}}
+	{base64url, ".*", {git, "https://github.com/dvv/base64url", {tag, "1.0.1"}}}
 ]}.


### PR DESCRIPTION
Jose depends on [base64url](https://github.com/dvv/base64url) 0.0.1 since https://github.com/potatosalad/erlang-jose/commit/ab042df070f84658e04ca629d67d4a101c47ccca 

The corresponding line in rebar.config uses a [syntax supported by Rebar3](http://rebar3.org/docs/configuration/dependencies/) but that syntax is [not supported by rebar2](https://github.com/rebar/rebar/wiki/Dependency-management)

So, right now:
```
$ ./rebar -V
rebar 2.6.4 17 20170823_084242 git 2.6.4-27-g8076675-dirty

$ ./rebar compile
==> jose (compile)
Dependency not available: base64url-0.0.1 ({pkg,base64url})
ERROR: compile failed while processing /home/badlop/jose: rebar_abort

$ ./rebar get-deps
==> jose (get-deps)
Pulling base64url from {pkg,base64url}
ERROR: 'get-deps' failed while processing /home/badlop/jose: {'EXIT',{function_clause,[{rebar_deps,source_engine_avail,
                                      [pkg,{pkg,base64url}],
                                      [{file,"src/rebar_deps.erl"},
                                       {line,783}]},
...
```

The solution is quite simple, use a syntax that is suported both by rebar2 and rebar3, as suggested some time ago (see
https://github.com/potatosalad/erlang-jose/issues/59#issuecomment-531169862)

Additionally, that offers a good chance to update base64url to 1.0.1, the most recent version, that was tagged seven months ago and includes just a minor change for rebar3.

With the fix:
```
$ ./rebar -V
rebar 2.6.4 17 20170823_084242 git 2.6.4-27-g8076675-dirty

$ ./rebar compile
==> jose (compile)
Dependency not available: base64url-.* ({git,
                                         "https://github.com/dvv/base64url",
                                         {tag,"1.0.1"}})
ERROR: compile failed while processing /home/badlop/jose: rebar_abort

$ ./rebar get-deps
==> jose (get-deps)
Pulling base64url from {git,"https://github.com/dvv/base64url",{tag,"1.0.1"}}
S'està clonant a «base64url»...
==> base64url (get-deps)

$ ./rebar compile
==> base64url (compile)
Compiled src/base64url.erl
==> jose (compile)
Compiled src/json/jose_json.erl
Compiled src/jwe/jose_jwe_enc.erl
Compiled src/jws/jose_jws_alg.erl
...
```

```
$ ./rebar3 -v
rebar 3.14.1 on Erlang/OTP 23 Erts 11.1.4

$ ./rebar3 compile
===> Verifying dependencies...
===> Fetching base64url (from {git,"https://github.com/dvv/base64url",{tag,"1.0.1"}})
===> Analyzing applications...
===> Compiling base64url
===> Analyzing applications...
===> Compiling jose
```

Jose test: success
https://github.com/badlop/erlang-jose/actions/runs/488694931

ejabberd test: success (it uses Jose for JWT user authentication and for ACME)
https://travis-ci.org/github/badlop/ejabberd/builds/754682722