### PR TITLE
Remove dependency on external base64url library, useless since 8e53209

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,6 +4,3 @@
 	debug_info,
 	warnings_as_errors
 ]}.
-{deps, [
-	{base64url, "0.0.1", {pkg, base64url}}
-]}.


### PR DESCRIPTION
As mentioned in https://github.com/potatosalad/erlang-jose/pull/108 , this library is no longer needed.