### PR TITLE
Add OTP 24 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - erlang: 24.0-alpine-3.13.3
           - erlang: 23.2-alpine-3.12.1
           - erlang: 22.2.1-alpine-3.12.0
 


### PR DESCRIPTION
Tests are currently failing due to compatibility issues that will be fixed.