### PR TITLE
Capture test logs on failure in Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,3 +25,10 @@ jobs:
       - name: Test
         run: |
           make docker-test DOCKER_OTP_VERSION=${{matrix.erlang}}
+
+      - name: Logs
+        uses: actions/upload-artifact@v2-preview
+        if: failure()
+        with:
+          name: logs
+          path: logs/*


### PR DESCRIPTION
The captures the common test logs from failed runs as a workflow artifact, for convenience in inspecting failures