### PR TITLE
Erlang 24 Compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,5 +30,5 @@ jobs:
         uses: actions/upload-artifact@v2-preview
         if: failure()
         with:
-          name: logs
+          name: ct-logs-${{matrix.erlang}}
           path: logs/*

--- a/src/jose_public_key.erl
+++ b/src/jose_public_key.erl
@@ -134,6 +134,8 @@ der_decode(DER) when is_binary(DER) ->
 	case Result of
 		PrivateKeyInfo=#'PrivateKeyInfo'{} ->
 			i2k(PrivateKeyInfo);
+		ECPrivateKey=#'ECPrivateKey'{} ->
+			i2k(ECPrivateKey);
 		SubjectPublicKeyInfo=#'SubjectPublicKeyInfo'{} ->
 			i2k(SubjectPublicKeyInfo);
 		Other ->
@@ -198,6 +200,8 @@ pem_entry_decode(PEMEntry) ->
 	case Result of
 		PrivateKeyInfo=#'PrivateKeyInfo'{} ->
 			i2k(PrivateKeyInfo);
+		ECPrivateKey=#'ECPrivateKey'{} ->
+			i2k(ECPrivateKey);
 		SubjectPublicKeyInfo=#'SubjectPublicKeyInfo'{} ->
 			i2k(SubjectPublicKeyInfo);
 		Other ->
@@ -220,6 +224,8 @@ pem_entry_decode(PEMEntry, Password) ->
 	case Result of
 		PrivateKeyInfo=#'PrivateKeyInfo'{} ->
 			i2k(PrivateKeyInfo);
+		ECPrivateKey=#'ECPrivateKey'{} ->
+			i2k(ECPrivateKey);
 		SubjectPublicKeyInfo=#'SubjectPublicKeyInfo'{} ->
 			i2k(SubjectPublicKeyInfo);
 		Other ->
@@ -760,6 +766,16 @@ i2k(#'PrivateKeyInfo'{
 		publicKey = #'jose_EdDSA25519PublicKey'{ publicKey = PublicKey },
 		privateKey = PrivateKey
 	};
+i2k(#'ECPrivateKey'{
+	   parameters = {namedCurve, ?'jose_id-EdDSA25519'},
+	   privateKey =
+		   << 4, 32:8/integer, PrivateKey:32/binary >>
+}) ->
+	PublicKey = jose_curve25519:eddsa_secret_to_public(PrivateKey),
+	#'jose_EdDSA25519PrivateKey'{
+	    publicKey = #'jose_EdDSA25519PublicKey'{ publicKey = PublicKey },
+	    privateKey = PrivateKey
+	};
 i2k(#'SubjectPublicKeyInfo'{
 	algorithm =
 		#'AlgorithmIdentifier'{
@@ -775,6 +791,16 @@ i2k(#'PrivateKeyInfo'{
 		},
 	privateKey =
 		<< 4, 57:8/integer, PrivateKey:57/binary >>
+}) ->
+	PublicKey = jose_curve448:eddsa_secret_to_public(PrivateKey),
+	#'jose_EdDSA448PrivateKey'{
+		publicKey = #'jose_EdDSA448PublicKey'{ publicKey = PublicKey },
+		privateKey = PrivateKey
+	};
+i2k(#'ECPrivateKey'{
+	   parameters = {namedCurve, ?'jose_id-EdDSA448'},
+	   privateKey =
+		   << 4, 57:8/integer, PrivateKey:57/binary >>
 }) ->
 	PublicKey = jose_curve448:eddsa_secret_to_public(PrivateKey),
 	#'jose_EdDSA448PrivateKey'{

--- a/src/jose_public_key.erl
+++ b/src/jose_public_key.erl
@@ -134,7 +134,9 @@ der_decode(DER) when is_binary(DER) ->
 	case Result of
 		PrivateKeyInfo=#'PrivateKeyInfo'{} ->
 			i2k(PrivateKeyInfo);
-		ECPrivateKey=#'ECPrivateKey'{} ->
+		ECPrivateKey={'ECPrivateKey', _, _, _, _, _} -> %% OTP 24
+			i2k(ECPrivateKey);
+		ECPrivateKey={'ECPrivateKey', _, _, _, _} -> %% OTP 23
 			i2k(ECPrivateKey);
 		SubjectPublicKeyInfo=#'SubjectPublicKeyInfo'{} ->
 			i2k(SubjectPublicKeyInfo);
@@ -200,7 +202,9 @@ pem_entry_decode(PEMEntry) ->
 	case Result of
 		PrivateKeyInfo=#'PrivateKeyInfo'{} ->
 			i2k(PrivateKeyInfo);
-		ECPrivateKey=#'ECPrivateKey'{} ->
+		ECPrivateKey={'ECPrivateKey', _, _, _, _, _} -> %% OTP 24
+			i2k(ECPrivateKey);
+		ECPrivateKey={'ECPrivateKey', _, _, _, _} -> %% OTP 23
 			i2k(ECPrivateKey);
 		SubjectPublicKeyInfo=#'SubjectPublicKeyInfo'{} ->
 			i2k(SubjectPublicKeyInfo);
@@ -224,7 +228,9 @@ pem_entry_decode(PEMEntry, Password) ->
 	case Result of
 		PrivateKeyInfo=#'PrivateKeyInfo'{} ->
 			i2k(PrivateKeyInfo);
-		ECPrivateKey=#'ECPrivateKey'{} ->
+		ECPrivateKey={'ECPrivateKey', _, _, _, _, _} -> %% OTP 24
+			i2k(ECPrivateKey);
+		ECPrivateKey={'ECPrivateKey', _, _, _, _} -> %% OTP 23
 			i2k(ECPrivateKey);
 		SubjectPublicKeyInfo=#'SubjectPublicKeyInfo'{} ->
 			i2k(SubjectPublicKeyInfo);
@@ -766,11 +772,17 @@ i2k(#'PrivateKeyInfo'{
 		publicKey = #'jose_EdDSA25519PublicKey'{ publicKey = PublicKey },
 		privateKey = PrivateKey
 	};
-i2k(#'ECPrivateKey'{
-	   parameters = {namedCurve, ?'jose_id-EdDSA25519'},
-	   privateKey =
-		   << 4, 32:8/integer, PrivateKey:32/binary >>
-}) ->
+i2k({'ECPrivateKey', _,
+	 << 4, 32:8/integer, PrivateKey:32/binary >>,
+	 {namedCurve, ?'jose_id-EdDSA25519'}, _, _}) ->
+	PublicKey = jose_curve25519:eddsa_secret_to_public(PrivateKey),
+	#'jose_EdDSA25519PrivateKey'{
+	    publicKey = #'jose_EdDSA25519PublicKey'{ publicKey = PublicKey },
+	    privateKey = PrivateKey
+	};
+i2k({'ECPrivateKey', _,
+	 << 4, 32:8/integer, PrivateKey:32/binary >>,
+	 {namedCurve, ?'jose_id-EdDSA25519'}, _, _, _}) ->
 	PublicKey = jose_curve25519:eddsa_secret_to_public(PrivateKey),
 	#'jose_EdDSA25519PrivateKey'{
 	    publicKey = #'jose_EdDSA25519PublicKey'{ publicKey = PublicKey },
@@ -797,11 +809,17 @@ i2k(#'PrivateKeyInfo'{
 		publicKey = #'jose_EdDSA448PublicKey'{ publicKey = PublicKey },
 		privateKey = PrivateKey
 	};
-i2k(#'ECPrivateKey'{
-	   parameters = {namedCurve, ?'jose_id-EdDSA448'},
-	   privateKey =
-		   << 4, 57:8/integer, PrivateKey:57/binary >>
-}) ->
+i2k({'ECPrivateKey', _,
+	 << 4, 57:8/integer, PrivateKey:57/binary >>,
+	 {namedCurve, ?'jose_id-EdDSA448'}, _, _}) ->
+	PublicKey = jose_curve448:eddsa_secret_to_public(PrivateKey),
+	#'jose_EdDSA448PrivateKey'{
+		publicKey = #'jose_EdDSA448PublicKey'{ publicKey = PublicKey },
+		privateKey = PrivateKey
+	};
+i2k({'ECPrivateKey', _,
+	 << 4, 57:8/integer, PrivateKey:57/binary >>,
+	 {namedCurve, ?'jose_id-EdDSA448'}, _, _, _}) ->
 	PublicKey = jose_curve448:eddsa_secret_to_public(PrivateKey),
 	#'jose_EdDSA448PrivateKey'{
 		publicKey = #'jose_EdDSA448PublicKey'{ publicKey = PublicKey },

--- a/src/jwa/jose_jwa.erl
+++ b/src/jwa/jose_jwa.erl
@@ -73,24 +73,40 @@ block_encrypt(Cipher, Key, PlainText)
 
 block_decrypt(Cipher, Key, IV, CipherText)
 		when is_binary(CipherText) ->
-	{Module, BlockCipher} = block_cipher(Cipher),
-	Module:block_decrypt(BlockCipher, Key, IV, CipherText);
+	case block_cipher(Cipher) of
+		{crypto, BlockCipher} ->
+			jose_crypto_compat:crypto_one_time(BlockCipher, Key, IV, CipherText, false);
+		{Module, BlockCipher} ->
+			Module:block_decrypt(BlockCipher, Key, IV, CipherText)
+	end;
 block_decrypt(Cipher, Key, IV, {AAD, CipherText, CipherTag})
 		when is_binary(AAD)
 		andalso is_binary(CipherText)
 		andalso is_binary(CipherTag) ->
-	{Module, BlockCipher} = block_cipher(Cipher),
-	Module:block_decrypt(BlockCipher, Key, IV, {AAD, CipherText, CipherTag}).
+	case block_cipher(Cipher) of
+		{crypto, BlockCipher} ->
+			jose_crypto_compat:crypto_one_time(BlockCipher, Key, IV, {AAD, CipherText, CipherTag}, false);
+		{Module, BlockCipher} ->
+			Module:block_decrypt(BlockCipher, Key, IV, {AAD, CipherText, CipherTag})
+	end.
 
 block_encrypt(Cipher, Key, IV, PlainText)
 		when is_binary(PlainText) ->
-	{Module, BlockCipher} = block_cipher(Cipher),
-	Module:block_encrypt(BlockCipher, Key, IV, PlainText);
+	case block_cipher(Cipher) of
+		{crypto, BlockCipher} ->
+			jose_crypto_compat:crypto_one_time(BlockCipher, Key, IV, PlainText, true);
+		{Module, BlockCipher} ->
+			Module:block_encrypt(BlockCipher, Key, IV, PlainText)
+	end;
 block_encrypt(Cipher, Key, IV, {AAD, PlainText})
 		when is_binary(AAD)
 		andalso is_binary(PlainText) ->
-	{Module, BlockCipher} = block_cipher(Cipher),
-	Module:block_encrypt(BlockCipher, Key, IV, {AAD, PlainText}).
+	case block_cipher(Cipher) of
+		{crypto, BlockCipher} ->
+			jose_crypto_compat:crypto_one_time(BlockCipher, Key, IV, {AAD, PlainText}, true);
+		{Module, BlockCipher} ->
+			Module:block_encrypt(BlockCipher, Key, IV, {AAD, PlainText})
+	end.
 
 %%====================================================================
 %% Public Key API functions

--- a/src/jwa/jose_jwa.erl
+++ b/src/jwa/jose_jwa.erl
@@ -56,8 +56,8 @@ end).
 block_decrypt(Cipher, Key, CipherText)
 		when is_binary(CipherText) ->
 	case block_cipher(Cipher) of
-		{crypto, aes_ecb} ->
-			<< << (jose_crypto_compat:crypto_one_time(aes_128_ecb, Key, Block, false))/binary >> || << Block:128/bitstring >> <= CipherText >>;
+		{crypto, BlockCipher} ->
+			jose_crypto_compat:crypto_one_time(BlockCipher, Key, CipherText, false);
 		{Module, BlockCipher} ->
 			Module:block_decrypt(BlockCipher, Key, CipherText)
 	end.
@@ -65,8 +65,8 @@ block_decrypt(Cipher, Key, CipherText)
 block_encrypt(Cipher, Key, PlainText)
 		when is_binary(PlainText) ->
 	case block_cipher(Cipher) of
-		{crypto, aes_ecb} ->
-			<< << (jose_crypto_compat:crypto_one_time(aes_128_ecb, Key, Block, true))/binary >> || << Block:128/bitstring >> <= PlainText >>;
+		{crypto, BlockCipher} ->
+			jose_crypto_compat:crypto_one_time(BlockCipher, Key, PlainText, true);
 		{Module, BlockCipher} ->
 			Module:block_encrypt(BlockCipher, Key, PlainText)
 	end.


### PR DESCRIPTION
The block_decrypt API was deprecated in Erlang 23 and removed in 24. This provides Erlang 24 compatibility.