### PR TITLE
Adjust jose version

### DIFF
--- a/src/jose.app.src
+++ b/src/jose.app.src
@@ -2,7 +2,7 @@
 %% vim: ts=4 sw=4 ft=erlang noet
 {application, jose, [
 	{description, "JSON Object Signing and Encryption (JOSE) for Erlang and Elixir."},
-	{vsn, "1.11.1"},
+	{vsn, "1.11.3"},
 	{id, "git"},
 	{mod, {'jose_app', []}},
 	{registered, []},


### PR DESCRIPTION
jose was released and published at hex.pm as 1.11.2, but in .app.src still use 1.11.1.
This forces rebar3 constantly check jose for updates on every action and show wrong
version in `rebar3 tree`. Since 1.11.1 already published as 1.11.2 change app version
to 1.11.3 for adjusting version between `.app.src`, git tag and hex.pm release.