### PR TITLE
Support Ed25519 in native OTP 23+

### DIFF
--- a/src/jose_curve25519_otp.erl
+++ b/src/jose_curve25519_otp.erl
@@ -1,0 +1,73 @@
+%% -*- mode: erlang; tab-width: 4; indent-tabs-mode: 1; st-rulers: [70] -*-
+%% vim: ts=4 sw=4 ft=erlang noet
+%%%-------------------------------------------------------------------
+%%% @author Brett Beatty <brettbeatty@gmail.com>
+%%% @copyright 2021, Brett Beatty
+%%% @doc
+%%%
+%%% @end
+%%% Created :  22 Oct 2021 by Brett Beatty <brettbeatty@gmail.com>
+%%%-------------------------------------------------------------------
+-module(jose_curve25519_otp).
+
+-behaviour(jose_curve25519).
+
+%% jose_curve25519 callbacks
+-export([eddsa_keypair/0]).
+-export([eddsa_keypair/1]).
+-export([eddsa_secret_to_public/1]).
+-export([ed25519_sign/2]).
+-export([ed25519_verify/3]).
+-export([ed25519ph_sign/2]).
+-export([ed25519ph_verify/3]).
+-export([x25519_keypair/0]).
+-export([x25519_keypair/1]).
+-export([x25519_secret_to_public/1]).
+-export([x25519_shared_secret/2]).
+
+%%====================================================================
+%% jose_curve25519 callbacks
+%%====================================================================
+
+% EdDSA
+eddsa_keypair() ->
+	{PublicKey, Secret} = crypto:generate_key(eddsa, ed25519),
+	{PublicKey, <<Secret/binary, PublicKey/binary>>}.
+
+eddsa_keypair(<<Secret:32/binary>>) ->
+	{PublicKey, Secret} = crypto:generate_key(eddsa, ed25519, Secret),
+	{PublicKey, <<Secret/binary, PublicKey/binary>>}.
+
+eddsa_secret_to_public(<<Secret:32/binary>>) ->
+	{PublicKey, _} = crypto:generate_key(eddsa, ed25519, Secret),
+	PublicKey.
+
+% Ed25519
+ed25519_sign(Message, <<Secret:32/binary, _:32/binary>>) ->
+	crypto:sign(eddsa, none, Message, [Secret, ed25519]).
+
+ed25519_verify(Signature, Message, <<PublicKey:32/binary>>) ->
+	crypto:verify(eddsa, none, Message, Signature, [PublicKey, ed25519]).
+
+% Ed25519ph
+ed25519ph_sign(Message, SecretKey) ->
+	Hash = crypto:hash(sha512, Message),
+	ed25519_sign(Hash, SecretKey).
+
+ed25519ph_verify(Signature, Message, PublicKey) ->
+	Hash = crypto:hash(sha512, Message),
+	ed25519_verify(Signature, Hash, PublicKey).
+
+% X25519
+x25519_keypair() ->
+	crypto:generate_key(ecdh, x25519).
+
+x25519_keypair(<<Secret:32/binary>>) ->
+	crypto:generate_key(ecdh, x25519, Secret).
+
+x25519_secret_to_public(<<Secret:32/binary>>) ->
+	{PublicKey, _} = crypto:generate_key(ecdh, x25519, Secret),
+	PublicKey.
+
+x25519_shared_secret(MySecretKey, YourPublicKey) ->
+	crypto:compute_key(ecdh, YourPublicKey, MySecretKey, x25519).

--- a/src/jose_curve448_otp.erl
+++ b/src/jose_curve448_otp.erl
@@ -1,0 +1,90 @@
+%% -*- mode: erlang; tab-width: 4; indent-tabs-mode: 1; st-rulers: [70] -*-
+%% vim: ts=4 sw=4 ft=erlang noet
+%%%-------------------------------------------------------------------
+%%% @author Brett Beatty <brettbeatty@gmail.com>
+%%% @copyright 2021, Brett Beatty
+%%% @doc
+%%%
+%%% @end
+%%% Created :  22 Oct 2021 by Brett Beatty <brettbeatty@gmail.com>
+%%%-------------------------------------------------------------------
+-module(jose_curve448_otp).
+
+-behaviour(jose_curve448).
+
+%% jose_curve448 callbacks
+-export([eddsa_keypair/0]).
+-export([eddsa_keypair/1]).
+-export([eddsa_secret_to_public/1]).
+-export([ed448_sign/2]).
+-export([ed448_sign/3]).
+-export([ed448_verify/3]).
+-export([ed448_verify/4]).
+-export([ed448ph_sign/2]).
+-export([ed448ph_sign/3]).
+-export([ed448ph_verify/3]).
+-export([ed448ph_verify/4]).
+-export([x448_keypair/0]).
+-export([x448_keypair/1]).
+-export([x448_secret_to_public/1]).
+-export([x448_shared_secret/2]).
+
+%% Macros
+-define(unsupported, erlang:error(not_yet_implemented)).
+
+%%====================================================================
+%% jose_curve448 callbacks
+%%====================================================================
+
+% EdDSA
+eddsa_keypair() ->
+	{PublicKey, Secret} = crypto:generate_key(eddsa, ed448),
+	{PublicKey, <<Secret/binary, PublicKey/binary>>}.
+
+eddsa_keypair(<<Secret:57/binary>>) ->
+	{PublicKey, Secret} = crypto:generate_key(eddsa, ed448, Secret),
+	{PublicKey, <<Secret/binary, PublicKey/binary>>}.
+
+eddsa_secret_to_public(<<Secret:57/binary>>) ->
+	{PublicKey, _} = crypto:generate_key(eddsa, ed448, Secret),
+	PublicKey.
+
+% Ed448
+ed448_sign(Message, <<Secret:57/binary, _:57/binary>>) ->
+	crypto:sign(eddsa, none, Message, [Secret, ed448]).
+
+ed448_sign(_Message, _SecretKey, _Context) ->
+	?unsupported.
+
+ed448_verify(Signature, Message, <<PublicKey:57/binary>>) ->
+	crypto:verify(eddsa, none, Message, Signature, [PublicKey, ed448]).
+
+ed448_verify(_Signature, _Message, _PublicKey, _Context) ->
+	?unsupported.
+
+% Ed448ph
+ed448ph_sign(_Message, _SecretKey) ->
+	?unsupported.
+
+ed448ph_sign(_Message, _SecretKey, _Context) ->
+	?unsupported.
+
+ed448ph_verify(_Signature, _Message, _PublicKey) ->
+	?unsupported.
+
+ed448ph_verify(_Signature, _Message, _PublicKey, _Context) ->
+	?unsupported.
+
+% X448
+x448_keypair() ->
+	crypto:generate_key(ecdh, x448).
+
+x448_keypair(<<Secret:56/binary>>) ->
+	crypto:generate_key(ecdh, x448, Secret).
+
+x448_secret_to_public(<<Secret:56/binary>>) ->
+	{PublicKey, _} = crypto:generate_key(ecdh, x448, Secret),
+	PublicKey.
+
+x448_shared_secret(MySecretKey, YourPublicKey) ->
+	crypto:compute_key(ecdh, YourPublicKey, MySecretKey, x448).


### PR DESCRIPTION
Decided to take a crack at #91. I just have the 25519 curve so far, no 448. I thought to not break previous versions there'd just be an OTP-native implementation developers could choose instead of libdecaf/libsodium. But I'm not that experienced with erlang or crypto, so I had some questions:

1. What's the best way to test this? I had thought I'd just copy the tests for `:jose_jwa_curve25519`, but I haven't been able to run the tests locally (tried docker-build/docker-test and make tests and kept running into snags), so I thought I'd check. In manual testing I just compared the output of these functions to those in `:jose_jwa_curve25519`.
2. What does the module need to do to not cause problems for OTP versions before 23 (I've only tried it in 24)?