### PR TITLE
Hide kty in %JOSE.JWK{} when it is inspected

### DIFF
--- a/lib/jose/jwk.ex
+++ b/lib/jose/jwk.ex
@@ -10,6 +10,7 @@ defmodule JOSE.JWK do
   vals = :lists.map(&{&1, [], nil}, keys)
   pairs = :lists.zip(keys, vals)
 
+  @derive {Inspect, except: [:kty]}
   defstruct keys
   @type t :: %__MODULE__{}
 
@@ -782,7 +783,7 @@ defmodule JOSE.JWK do
     :jose_jwk.box_encrypt_ecdh_es(plain_text, jwe, v_static_public_key, u_ephemeral_secret_key)
   end
 
-    @doc """
+  @doc """
   ECDH-SS Key Agreement decryption of the `encrypted` binary or map using `v_static_secret_key`.  See `box_encrypt_ecdh_ss/2` and `JOSE.JWE.block_decrypt/2`.
   """
   def box_decrypt_ecdh_ss(encrypted, v_static_secret_key) do

--- a/test/jose_test.exs
+++ b/test/jose_test.exs
@@ -278,7 +278,7 @@ defmodule JOSETest do
     assert jwk == :erlang.element(2, JOSE.JWK.from_map(password, JOSE.JWK.to_map(password, jwk)))
     assert jwk == JOSE.JWK.from_pem(password, JOSE.JWK.to_pem(password, jwk))
     # hide private attributes
-    stdout = capture_io(fn -> IO.inspect(jwk) end)
+    stdout = inspect(jwk)
     assert match?("#JOSE.JWK<" <> _, stdout)
     refute String.contains?(stdout, "kty")
   end

--- a/test/jose_test.exs
+++ b/test/jose_test.exs
@@ -1,5 +1,6 @@
 defmodule JOSETest do
   use ExUnit.Case, async: false
+  import ExUnit.CaptureIO
 
   setup_all do
     JOSE.crypto_fallback(true)
@@ -276,6 +277,10 @@ defmodule JOSETest do
     assert jwk == :erlang.element(2, JOSE.JWK.from_binary(password, JOSE.JWK.to_binary(password, jwk)))
     assert jwk == :erlang.element(2, JOSE.JWK.from_map(password, JOSE.JWK.to_map(password, jwk)))
     assert jwk == JOSE.JWK.from_pem(password, JOSE.JWK.to_pem(password, jwk))
+    # hide private attributes
+    stdout = capture_io(fn -> IO.inspect(jwk) end)
+    assert match?("#JOSE.JWK<" <> _, stdout)
+    refute String.contains?(stdout, "kty")
   end
 
   test "JOSE.JWS decode and encode" do

--- a/test/jose_test.exs
+++ b/test/jose_test.exs
@@ -1,6 +1,5 @@
 defmodule JOSETest do
   use ExUnit.Case, async: false
-  import ExUnit.CaptureIO
 
   setup_all do
     JOSE.crypto_fallback(true)
@@ -277,7 +276,18 @@ defmodule JOSETest do
     assert jwk == :erlang.element(2, JOSE.JWK.from_binary(password, JOSE.JWK.to_binary(password, jwk)))
     assert jwk == :erlang.element(2, JOSE.JWK.from_map(password, JOSE.JWK.to_map(password, jwk)))
     assert jwk == JOSE.JWK.from_pem(password, JOSE.JWK.to_pem(password, jwk))
-    # hide private attributes
+  end
+
+  test "JOSE.JWK display" do
+    map = %{
+      "crv" => "P-256",
+      "d" => "aJhYDBNS-5yrH97PAExzWNLlJGqJwFGZmv7iJvdG4p0",
+      "kty" => "EC",
+      "x" => "LksdLpZN3ijcn_TBfRK-_tgmvws0c5_V5k0bg14RLhU",
+      "y" => "ukc-JOEAWhW664SY5Q29xHlAVEDlrQwYF3-vQ_cdi1s"
+    }
+
+    jwk = JOSE.JWK.from_map(map)
     stdout = inspect(jwk)
     assert match?("#JOSE.JWK<" <> _, stdout)
     refute String.contains?(stdout, "kty")


### PR DESCRIPTION
This idea spawned from [this discussion](https://github.com/joken-elixir/joken/issues/383)

Here is what the output would look like for an elixir client using Joken
```elixir
iex(1)> signer = Joken.Signer.create("HS256", "s3cret")
%Joken.Signer{
  jwk: #JOSE.JWK<keys: :undefined, fields: %{}, ...>,
  jws: %JOSE.JWS{
    alg: {:jose_jws_alg_hmac, :HS256},
    b64: :undefined,
    fields: %{"typ" => "JWT"}
  },
  alg: "HS256"
}
```

I am not sure if the `keys` or `fields` defined in the [jose_jwk](https://github.com/potatosalad/erlang-jose/blob/991649695aaccd92c8effb1c1e88e6159fe8e9a6/include/jose_jwk.hrl) record would ever hold private information, but I am hoping that this can start a discussion. 