### PR TITLE
Use 'sha256' instead of 'sha' when validating RSA signing supportability

### DIFF
--- a/src/jose_server.erl
+++ b/src/jose_server.erl
@@ -647,7 +647,7 @@ check_rsa_sign(Fallback) ->
 			future
 	end,
 	SignEntries = [begin
-		case has_rsa_sign(Padding, Legacy, sha) of
+		case has_rsa_sign(Padding, Legacy, sha256) of
 			false ->
 				{{rsa_sign, Padding}, {Fallback, [{rsa_padding, Padding}]}};
 			{true, Module} ->


### PR DESCRIPTION
In Openssl 3.0.1 in default configuration, `jose_server.erl` will determine that no `RS*` algorithms are supported for signing. The reason for this is usage of `sha` for DigestType when determining RSA signing supportability.

This breaks various flows even though 2 workarounds exist (both of which are not satisfactory enough in our case):
1) Set JOSE `crypto_fallback` env var to `true`
2) Allow explicitly RSA+SHA1 signatures in openssl config

I propose we change the DigestType to `sha256`, since `sha1` signature creation will probably be disabled in the future on both RHEL 9 and RHEL 10, based on info from [1].

Currently, SHA1+RSA signature creation is not allowed in OpenSSL configuration on public cloud Alma Linux images. Where the config is hardened to disallow certain signature algorithms. On those machines, example output of `JOSE.JWA.supports()` is as follows:

```
...
{:jws,
   {:alg, [“ES256”, “ES384", “ES512”, “HS256", “HS384”, “HS512", “Poly1305”]}} 
....
```

If we use `sha256` to create and validate RSA signing algorithms, the supported list becomes correct:

```
...
{:jws,
   {:alg,  [“ES256”, “ES384", “ES512”, “HS256", “HS384”, “HS512", “PS256”, “PS384", “PS512”, “Poly1305", “RS256”, “RS384", “RS512”]}} 
....
```


**Setup:**

Alma Linux 9.1
OpenSSL 3.0.1
Elixir 1.14.0-otp-25
Erlang 25.0.4
jose 1.11.2



[1] https://github.com/openssl/openssl/issues/17662