### PR TITLE
Declare Poison as an optional dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,8 @@ defmodule JOSE.Mixfile do
       {:libdecaf, "~> 2.1.1", only: [:dev, :test]},
       {:libsodium, "~> 2.0.1", only: [:dev, :test]},
       {:ojson, "~> 1.0", only: [:dev, :test]},
-      {:poison, "~> 5.0", only: [:dev, :test]},
+      # Optionally used by JOSE.Poison.
+      {:poison, "~> 3.0 or ~> 4.0 or ~> 5.0", optional: true},
       {:thoas, "~> 1.0", only: [:dev, :test]},
       {:ex_doc, "~> 0.30", only: :dev},
       {:earmark, "~> 1.4", only: :dev}


### PR DESCRIPTION
Related to https://github.com/potatosalad/erlang-jose/pull/98.

Poison is optionally depended on by JOSE.Poison, which is conditionally compiled in. Mix should know that this dependency exists, so that Poison is compiled first, and available during JOSE's compilation when used.

Since Poison is very heavily depended on, I picked the last few major versions to avoid dependency hell when pulling in other libraries that might still depend on an older version. It seems to me that all of these should be compatible with JOSE.Poison, as I only see it depend on Poison.EncodeError which has been around for a long time.