### PR TITLE
Ensure 'jiffy:encode/1' returns a binary

### DIFF
--- a/src/json/jose_json_jiffy.erl
+++ b/src/json/jose_json_jiffy.erl
@@ -23,11 +23,11 @@ decode(Binary) ->
 	jiffy:decode(Binary, [return_maps]).
 
 encode(Map) when is_map(Map) ->
-	jiffy:encode(sort(Map));
+	ensure_binary(jiffy:encode(sort(Map)));
 encode(List) when is_list(List) ->
-	jiffy:encode(sort(List));
+	ensure_binary(jiffy:encode(sort(List)));
 encode(Term) ->
-	jiffy:encode(Term).
+	ensure_binary(jiffy:encode(Term)).
 
 %%%-------------------------------------------------------------------
 %%% Internal functions
@@ -40,3 +40,11 @@ sort(List) when is_list(List) ->
 	[sort(Term) || Term <- List];
 sort(Term) ->
 	Term.
+
+%% @private
+%% NOTE: jiffy may return an iolist instead of a binary when encoding
+%%       big objects.
+ensure_binary(List) when is_list(List) ->
+	iolist_to_binary(List);
+ensure_binary(Binary) ->
+	Binary.


### PR DESCRIPTION
## Description

`jiffy` may return an `iolist` instead of a `binary` when encoding big objects (see details [here](https://github.com/davisp/jiffy/issues/220)). This leads to problems inside `jose` as it expects the plaintext to be a `binary` when signing a token (see [here](https://github.com/potatosalad/erlang-jose/blob/main/src/jws/jose_jws.erl#L261)).