### PR TITLE
Fix #96

### DIFF
--- a/src/jwk/jose_jwk_openssh_key.erl
+++ b/src/jwk/jose_jwk_openssh_key.erl
@@ -127,7 +127,7 @@ parse_key(<< W, Rest/binary >>, Body)
 		orelse W =:= $\t ->
 	parse_key(Rest, Body);
 parse_key(<< ?OPENSSH_TAIL, Rest/binary >>, Body) ->
-	case parse_key(jose_base64:decode(Body)) of
+	case parse_key(jose_base64:'decode!'(Body)) of
 		{true, Key} ->
 			{Key, Rest};
 		false ->

--- a/test/jose_test.exs
+++ b/test/jose_test.exs
@@ -544,4 +544,12 @@ defmodule JOSETest do
     assert({:error, _} = JOSE.JWT.verify(jwk, nil))
     assert({:error, _} = JOSE.JWT.verify_strict(jwk, [], nil))
   end
+
+  # See https://github.com/potatosalad/erlang-jose/issues/96
+  test "reads valid openssh keys" do
+    input =
+      "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\nQyNTUxOQAAACAvwUoBPsC8rc4wpR1xbN3Onjuuo+2gqLNECWvmUlDEpQAAAKA6FC8aOhQv\nGgAAAAtzc2gtZWQyNTUxOQAAACAvwUoBPsC8rc4wpR1xbN3Onjuuo+2gqLNECWvmUlDEpQ\nAAAEBXwZ8kolKDzWxBdcPJT0KXilyZEfbF/GjyGa4AOf2d5C/BSgE+wLytzjClHXFs3c6e\nO66j7aCos0QJa+ZSUMSlAAAAFmRtb3JuQHNpbHZlci5mcml0ei5ib3gBAgMEBQYH\n-----END OPENSSH PRIVATE KEY-----\n"
+
+    assert %JOSE.JWK{kty: {:jose_jwk_kty_okp_ed25519, _}} = JOSE.JWK.from_openssh_key(input)
+  end
 end


### PR DESCRIPTION
As mentioned in #96, `decode` is indeed returning a tuple, which is not valid argument for the `parse_key` function. It may be better to return an error in case the decode fails instead of raising, let me know if you want to change that!