### PR TITLE
Make default ex_doc page the README

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule JOSE.Mixfile do
 
         [
           source_ref: ref,
-          main: "JOSE",
+          main: "readme",
           extras: ["README.md", "CHANGELOG.md", "examples/KEY-GENERATION.md", "ALGORITHMS.md"],
           groups_for_modules: ["Elixir": [~r/JOSE/], Erlang: [~r/jose/]]
         ]


### PR DESCRIPTION
This is just a tiny opinionated documentation change.

I didn't notice all the useful docs in the README, as I was looking at the ex_docs which [defaults to the JOSE module](https://hexdocs.pm/jose/).

This PR changes the default page to the [README](https://hexdocs.pm/jose/readme.html), which has lots of example code and is much more useful.