### PR TITLE
Fix dialyxir config

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule JOSE.Mixfile do
       {:thoas, "~> 1.0", only: [:dev, :test]},
       {:ex_doc, "~> 0.30", only: :dev},
       {:earmark, "~> 1.4", only: :dev},
-      {:dialyxir, "~> 1.4.3"}
+      {:dialyxir, "~> 1.4.3", only: [:dev, :test], runtime: false}
     ]
   end
 


### PR DESCRIPTION
Updates the dialyxir config to only load in test and dev, resolving dep conflicts in Elixir projects.

Resolves warning:
```
Warning: the `dialyxir` application's start function was called, which likely means you
did not add the dependency with the `runtime: false` flag. This is not recommended because
it will mean that unnecessary applications are started, and unnecessary applications are most
likely being added to your PLT file, increasing build time.
```

Resolves deps conflict:
 ```
 Unchecked dependencies for environment dev:
* dialyxir (Hex package)
  the :only option for dependency dialyxir

  > In mix.exs:
    {:dialyxir, "~> 1.0", [env: :prod, hex: "dialyxir", only: [:dev], runtime: false, repo: "hexpm"]}

  does not match the :only option calculated for

  > In deps/jose/mix.exs:
    {:dialyxir, "~> 1.4.3", [env: :prod, hex: "dialyxir", repo: "hexpm", optional: false]}

  Remove the :only restriction from your dep
** (Mix) Can't continue due to errors on dependencies
```