### PR TITLE
Load dialyxir only in :dev

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule JOSE.Mixfile do
       {:thoas, "~> 1.0", only: [:dev, :test]},
       {:ex_doc, "~> 0.30", only: :dev},
       {:earmark, "~> 1.4", only: :dev},
-      {:dialyxir, "~> 1.4.3"}
+      {:dialyxir, "~> 1.4.3", only: :dev, runtime: false}
     ]
   end
 


### PR DESCRIPTION
We're currently encountering the following problem:
![image](https://github.com/potatosalad/erlang-jose/assets/1214337/658e71cb-94ed-4765-ae6d-efbb1d03190f)

I believe this PR fixes that.