### PR TITLE
Fix JOSE.JWE.compact/1 @spec

### DIFF
--- a/lib/jose/jwe.ex
+++ b/lib/jose/jwe.ex
@@ -587,7 +587,7 @@ defmodule JOSE.JWE do
 
   See `expand/1`.
   """
-  @spec compact(map()) :: {map(), binary()}
+  @spec compact(map() | {map(), map()}) :: {map(), binary()}
   defdelegate compact(encrypted), to: :jose_jwe
 
   @doc """


### PR DESCRIPTION
Hey there 👋🏾  thanks for the fantastic library! 🎉 

I figured out that there might be a `@spec` error when running dialyzer from my app.

The code is more or less this:

```elixir
jwk
|> JOSE.JWE.block_encrypt(Jason.encode!(payload), %{
  "alg" => @alg,
  "enc" => @enc
})
|> JOSE.JWE.compact()
|> elem(1)
```

The dialyzer complaint (from my side) is:

```elixir
The function call will not succeed.
JOSE.JWE.compact({%{:alg => atom(), :enc => atom(), :zip => atom()}, %{<<_::16, _::size(8)>> => binary()}}) ::
  :ok
def a() do
  :ok
end

breaks the contract
(map()) :: {map(), binary()}
```

PS: I am not sure if `{map(), map()}` is 100% correct. Please let me know