### PR TITLE
Improve `JWT.verify_strict/3` typespec with error tuple

### DIFF
--- a/lib/jose/jwt.ex
+++ b/lib/jose/jwt.ex
@@ -309,7 +309,8 @@ defmodule JOSE.JWT do
   @doc """
   Verifies the `signed` using the `jwk`, whitelists the `"alg"` using `allow`, and calls `from/1` on the payload.  See `JOSE.JWS.verify_strict/3`.
   """
-  @spec verify_strict(JOSE.JWK.t(), [String.t()], binary()) :: {valid? :: boolean(), jwt :: t(), jws :: JOSE.JWS.t()}
+  @spec verify_strict(JOSE.JWK.t(), [String.t()], binary()) ::
+          {valid? :: boolean(), jwt :: t(), jws :: JOSE.JWS.t()} | {:error, any()}
   def verify_strict(jwk = %JOSE.JWK{}, allow, signed), do: verify_strict(JOSE.JWK.to_record(jwk), allow, signed)
 
   def verify_strict(jwk = [%JOSE.JWK{} | _], allow, signed) do


### PR DESCRIPTION
Hey, thanks for the great lib! 🎉 

I think there might be an issue with the typespec for the mentioned function.

Currently `JOSE.JWT.verify_strict/3` returns, on some input, `{:error, any()}`.
However, this is not shown in the typespec - this causes the dialyzer to fail.

I'm attaching a demo script to test it out:
```elixir
Mix.install([
  {:jose, "~> 1.11"}
])

verify_strict = fn jwt ->
  """
  -----BEGIN PUBLIC KEY-----
  MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0xZi5oUFw1oeX6bMdLqMeb2b/RwR
  1VQhERuHUtlXWDKIKBKead6BEu0ClXiwBHDoGmyEnXjmitdzDUNmCLCMNA==
  -----END PUBLIC KEY-----
  """
  |> JOSE.JWK.from_pem()
  |> JOSE.JWK.to_map()
  |> JOSE.JWT.verify_strict(["ES256"], jwt)
end

# example of error outputs not present in the typespec
[
  "FOO",
  "{\"name\": \"John Doe\", \"age\": 30}",
  "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJmb28iLCJleHAiOjE1MTYyMzkwMjIsImlhdCI6MTUxNjIzOTAyMiwianRpIjoiYm9vIn0.5J6"
]
|> Enum.map(&verify_strict.(&1))
|> Enum.each(&IO.inspect(&1))

# {:error, {:badarg, ["FOO"]}}
# {:error, {:badarg, ["{\"name\": \"John Doe\", \"age\": 30}"]}}
# {:error, :unsupported_json_module}
```

This could fix #167, and partialy #164 too.