### PR TITLE
Disable warnings_as_error because of OTP deprecation warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -61,9 +61,7 @@ defmodule JOSE.Mixfile do
   end
 
   def erlc_options() do
-    extra_options = []
-
-    [:debug_info | if(Mix.env() == :prod, do: [], else: [:warnings_as_errors]) ++ extra_options]
+    [:debug_info]
   end
 
   defp package() do

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,3 @@
 %% -*- mode: erlang; tab-width: 4; indent-tabs-mode: 1; st-rulers: [70] -*-
 %% vim: ts=4 sw=4 ft=erlang noet
-{erl_opts, [
-	debug_info,
-	warnings_as_errors
-]}.
+{erl_opts, [debug_info]}.


### PR DESCRIPTION
Fixes #168