### PR TITLE
Support OTP json module

### DIFF
--- a/src/jose_server.erl
+++ b/src/jose_server.erl
@@ -458,9 +458,9 @@ check_json(_Fallback, Entries) ->
 				undefined ->
 					case code:ensure_loaded(elixir) of
 						{module, elixir} ->
-							check_json_modules([ojson, 'Elixir.Jason', 'Elixir.Poison', jiffy, jsone, jsx, thoas]);
+							check_json_modules([json, ojson, 'Elixir.Jason', 'Elixir.Poison', jiffy, jsone, jsx, thoas]);
 						_ ->
-							check_json_modules([ojson, jiffy, jsone, jsx, thoas])
+							check_json_modules([json, ojson, jiffy, jsone, jsx, thoas])
 					end;
 				M when is_atom(M) ->
 					check_json_module(M)
@@ -469,6 +469,8 @@ check_json(_Fallback, Entries) ->
 	[{json_module, JSONModule} | Entries].
 
 %% @private
+check_json_module(json) ->
+	jose_json_otp;
 check_json_module(jiffy) ->
 	jose_json_jiffy;
 check_json_module(jsx) ->

--- a/src/json/jose_json_otp.erl
+++ b/src/json/jose_json_otp.erl
@@ -1,0 +1,20 @@
+%% -*- mode: erlang; tab-width: 4; indent-tabs-mode: 1; st-rulers: [70] -*-
+%% vim: ts=4 sw=4 ft=erlang noet
+-module(jose_json_otp).
+-behaviour(jose_json).
+
+%% jose_json callbacks
+-export([decode/1]).
+-export([encode/1]).
+
+%%====================================================================
+%% jose_json callbacks
+%%====================================================================
+
+decode(Binary) -> json:decode(Binary).
+
+encode(Term) -> iolist_to_binary(json:encode(Term)).
+
+%%%-------------------------------------------------------------------
+%%% Internal functions
+%%%-------------------------------------------------------------------

--- a/test/jose_test.exs
+++ b/test/jose_test.exs
@@ -116,6 +116,18 @@ defmodule JOSETest do
     assert binary == :erlang.element(2, JOSE.JWE.to_binary(jwe))
     assert jwe == JOSE.JWE.from_binary(binary)
     assert jwe == JOSE.JWE.from(jwe)
+
+    if System.otp_release() >= "27" do
+      # OTP json
+      JOSE.json_module(:json)
+      assert :jose_json_otp == JOSE.json_module()
+      assert map == :erlang.element(2, JOSE.JWE.to_map(jwe))
+      assert binary == :erlang.element(2, JOSE.JWE.to_binary(jwe))
+      assert jwe == JOSE.JWE.from_binary(binary)
+      assert jwe == JOSE.JWE.from(jwe)
+    end
+
+    # jsx
     # # jiffy
     # JOSE.json_module(:jiffy)
     # assert :jose_json_jiffy == JOSE.json_module()


### PR DESCRIPTION
Implements #157 

Dialyzer Error is expected for testing with OTP < 27, should pass with #175.

Accidentally removed fork which closed the PR #170, re-opening.