### PR TITLE
Fix native Ed448 detection without crypto fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+* Fixes
+  * Detect native OTP Ed448 support without requiring the pure Erlang cryptographic fallback; see [#198](https://github.com/potatosalad/erlang-jose/issues/198).
+  * Report Ed25519, Ed25519ph, Ed448, and Ed448ph support only when their signing and verification operations are available.
+
 ## 1.11.12 (2025-11-20)
 
 * Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 * Fixes
   * Detect native OTP Ed448 support without requiring the pure Erlang cryptographic fallback; see [#198](https://github.com/potatosalad/erlang-jose/issues/198).
-  * Report Ed25519, Ed25519ph, Ed448, and Ed448ph support only when their signing and verification operations are available.
+  * Validate native and optional Ed25519 and Ed448 adapters against fallback-independent RFC 8032 test vectors.
+  * Report Ed25519, Ed25519ph, Ed448, and Ed448ph support only when their signing and verification operations are available, caching those operational checks until their adapter configuration changes.
 
 ## 1.11.12 (2025-11-20)
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Curve25519 and Curve448 and their associated signing/key exchange functions are 
 
 Fallback support for `Ed25519`, `Ed25519ph`, `Ed448`, `Ed448ph`, `X25519`, and `X448` is provided.  See [`crypto_fallback`](#cryptographic-algorithm-fallback) below.
 
+When no preferred external backend is present, JOSE selects OTP's native `crypto` adapters after their capability checks pass.
+
 External support is also provided by the following libraries:
 
  * [libdecaf](https://github.com/potatosalad/erlang-libdecaf) - `Ed25519`, `Ed25519ph`, `Ed448`, `Ed448ph`, `X25519`, `X448`
@@ -102,10 +104,12 @@ If both libraries are present, libdecaf will be used by default.  Other modules 
 ```elixir
 # Curve25519
 JOSE.curve25519_module(:libdecaf)            # uses a fast Erlang NIF for libdecaf
+JOSE.curve25519_module(:crypto)              # uses native OTP crypto operations
 JOSE.curve25519_module(:jose_jwa_curve25519) # uses the pure Erlang implementation (slow)
 
 # Curve448
 JOSE.curve448_module(:libdecaf)          # uses a fast Erlang NIF for libdecaf
+JOSE.curve448_module(:crypto)            # uses native OTP crypto operations
 JOSE.curve448_module(:jose_jwa_curve448) # uses the pure Erlang implementation (slow)
 ```
 

--- a/lib/jose.ex
+++ b/lib/jose.ex
@@ -70,6 +70,7 @@ defmodule JOSE do
 
     * [`libdecaf`](https://github.com/potatosalad/erlang-libdecaf)
     * [`libsodium`](https://github.com/potatosalad/erlang-libsodium)
+    * `crypto` - uses native OTP Ed25519 and X25519 operations when available
     * `jose_jwa_curve25519` - only supported when `crypto_fallback/0` is `true`
 
   Additional modules that implement the `jose_curve25519` behavior may also be used.
@@ -91,6 +92,7 @@ defmodule JOSE do
   Currently supported Curve448 modules (first found is used as default):
 
     * [`libdecaf`](https://github.com/potatosalad/erlang-libdecaf)
+    * `crypto` - uses native OTP Ed448 and X448 operations when available
     * `jose_jwa_curve448` - only supported when `crypto_fallback/0` is `true`
 
   Additional modules that implement the `jose_curve448` behavior may also be used.

--- a/src/jose_server.erl
+++ b/src/jose_server.erl
@@ -409,9 +409,8 @@ check_curve448_modules(Fallback, [Module | Modules]) ->
 	case code:ensure_loaded(Module) of
 		{module, Module} ->
 			_ = application:ensure_all_started(Module),
-			RealFallback = jose_jwa_curve448,
 			RealModule = check_curve448_module(Module),
-			try check_curve448_module_does_it_work(RealFallback, RealModule) of
+			try check_curve448_module_does_it_work(RealModule) of
 				true ->
 					RealModule;
 				false ->
@@ -427,26 +426,25 @@ check_curve448_modules(Fallback, []) ->
 	Fallback.
 
 %% @private
-check_curve448_module_does_it_work(Fallback, Module) ->
-	{PK, SK = <<Secret:57/binary, _:57/binary>>} = Module:eddsa_keypair(),
+check_curve448_module_does_it_work(Module) ->
+	{GeneratedPK, <<GeneratedSecret:57/binary, GeneratedPK:57/binary>>} = Module:eddsa_keypair(),
+	GeneratedPK = Module:eddsa_secret_to_public(GeneratedSecret),
+	%% RFC 8032, section 7.4, blank-message Ed448 test vector.
+	Secret = base64:decode(<<
+		"bIKlYsuAjRDWMr6JyFE+v2ySnzTd+oyfY8mWDvbjSKNSjIo/zC8ETjmj/FuUSS+PAy51SaIAmPlb"
+	>>),
+	PK = base64:decode(<<
+		"X9dEm1m0Yf0s54fsYWrUah2hNCSFpw4fig6nXYDpZ3jt8SR2m0bHBhvWeD3x5Q9s0foavq/oJWGA"
+	>>),
+	Signature = base64:decode(<<
+		"Uzo39rvkVyUfAjwNiPl2ri37UEqEPjTSB0/YI9QaWR8rIz8DT2KCgfL9eiLd1H14KMWb0KIb/TmA/"
+		"w0gKNSxip32PgBsXRwtNFuSXY3AC0EEhS25msXHzdqFMKEToPTbthFJ8FpzYyaMcdlYCP8uZSYA"
+	>>),
+	Message = <<>>,
 	{PK, SK} = Module:eddsa_keypair(Secret),
 	PK = Module:eddsa_secret_to_public(Secret),
-	Message = crypto:strong_rand_bytes(16),
 	Signature = Module:ed448_sign(Message, SK),
-	true = Module:ed448_verify(Signature, Message, PK),
-	true = Fallback:ed448_verify(Signature, Message, PK),
-	%% NOTE: Ed448ph is lower priority, no need to check for now.
-	% Ctx = <<"ctx">>,
-	% CtxSignature = Module:ed448_sign(Message, SK, Ctx),
-	% true = Module:ed448_verify(CtxSignature, Message, PK, Ctx),
-	% true = Fallback:ed448_verify(CtxSignature, Message, PK, Ctx),
-	% PHSignature = Module:ed448ph_sign(Message, SK),
-	% true = Module:ed448ph_verify(PHSignature, Message, PK),
-	% true = Fallback:ed448ph_verify(PHSignature, Message, PK),
-	% CtxPHSignature = Module:ed448ph_sign(Message, SK, Ctx),
-	% true = Module:ed448ph_verify(CtxPHSignature, Message, PK, Ctx),
-	% true = Fallback:ed448ph_verify(CtxPHSignature, Message, PK, Ctx),
-	true.
+	true = Module:ed448_verify(Signature, Message, PK).
 
 %% @private
 check_json(_Fallback, Entries) ->

--- a/src/jose_server.erl
+++ b/src/jose_server.erl
@@ -18,6 +18,8 @@
 %% API
 -export([start_link/0]).
 -export([config_change/0]).
+-export([cache_crypto_supports/4]).
+-export([crypto_supports/0]).
 -export([chacha20_poly1305_module/1]).
 -export([curve25519_module/1]).
 -export([curve448_module/1]).
@@ -61,6 +63,21 @@ start_link() ->
 
 config_change() ->
 	gen_server:call(?SERVER, config_change).
+
+crypto_supports() ->
+	%% Snapshot configuration in the server, but run operational adapter probes
+	%% in the caller so a slow custom module cannot block configuration changes.
+	Snapshot = gen_server:call(?SERVER, crypto_supports_snapshot, infinity),
+	jose_jwa:crypto_supports_internal(Snapshot).
+
+cache_crypto_supports(Generation, CacheKey, ExternalHashs, ExternalPublicKeys) ->
+	gen_server:call(?SERVER, {
+		cache_crypto_supports,
+		Generation,
+		CacheKey,
+		ExternalHashs,
+		ExternalPublicKeys
+	}, infinity).
 
 chacha20_poly1305_module(ChaCha20Poly1305Module) when is_atom(ChaCha20Poly1305Module) ->
 	gen_server:call(?SERVER, {chacha20_poly1305_module, ChaCha20Poly1305Module}).
@@ -106,22 +123,24 @@ init([]) ->
 %% @private
 handle_call(config_change, _From, State) ->
 	{reply, support_check(), State};
+handle_call(crypto_supports_snapshot, _From, State) ->
+	{reply, crypto_supports_snapshot(), State};
+handle_call({cache_crypto_supports, Generation, CacheKey, ExternalHashs, ExternalPublicKeys}, _From, State) ->
+	Reply = cache_crypto_supports_internal(Generation, CacheKey, ExternalHashs, ExternalPublicKeys),
+	{reply, Reply, State};
 handle_call({chacha20_poly1305_module, M}, _From, State) ->
 	ChaCha20Poly1305Module = check_chacha20_poly1305_module(M),
 	Entries = lists:flatten(check_crypto(?CRYPTO_FALLBACK, [{chacha20_poly1305_module, ChaCha20Poly1305Module}])),
 	_ = ets:select_delete(?TAB, [{{{cipher, '_'}, '_'}, [], [true]}]),
-	true = ets:delete(?TAB, crypto_supports_external),
-	true = ets:insert(?TAB, Entries),
+	ok = update_crypto_supports_entries(Entries),
 	{reply, ok, State};
 handle_call({curve25519_module, M}, _From, State) ->
 	Curve25519Module = check_curve25519_module(M),
-	true = ets:delete(?TAB, crypto_supports_external),
-	true = ets:insert(?TAB, {curve25519_module, Curve25519Module}),
+	ok = update_crypto_supports_entries([{curve25519_module, Curve25519Module}]),
 	{reply, ok, State};
 handle_call({curve448_module, M}, _From, State) ->
 	Curve448Module = check_curve448_module(M),
-	true = ets:delete(?TAB, crypto_supports_external),
-	true = ets:insert(?TAB, {curve448_module, Curve448Module}),
+	ok = update_crypto_supports_entries([{curve448_module, Curve448Module}]),
 	{reply, ok, State};
 handle_call({json_module, M}, _From, State) ->
 	JSONModule = check_json_module(M),
@@ -132,8 +151,7 @@ handle_call({pbes2_count_maximum, PBES2CountMaximum}, _From, State) when is_inte
 	{reply, ok, State};
 handle_call({sha3_module, M}, _From, State) ->
 	SHA3Module = check_sha3_module(M),
-	true = ets:delete(?TAB, crypto_supports_external),
-	true = ets:insert(?TAB, {sha3_module, SHA3Module}),
+	ok = update_crypto_supports_entries([{sha3_module, SHA3Module}]),
 	{reply, ok, State};
 handle_call({unsecured_signing, UnsecuredSigning}, _From, State) when is_boolean(UnsecuredSigning) ->
 	true = ets:insert(?TAB, {unsecured_signing, UnsecuredSigning}),
@@ -146,7 +164,7 @@ handle_call({xchacha20_poly1305_module, M}, _From, State) ->
 	XChaCha20Poly1305Module = check_xchacha20_poly1305_module(M),
 	Entries = lists:flatten(check_crypto(?CRYPTO_FALLBACK, [{xchacha20_poly1305_module, XChaCha20Poly1305Module}])),
 	_ = ets:select_delete(?TAB, [{{{cipher, '_'}, '_'}, [], [true]}]),
-	true = ets:insert(?TAB, Entries),
+	ok = update_crypto_supports_entries(Entries),
 	{reply, ok, State};
 handle_call(_Request, _From, State) ->
 	{reply, ignore, State}.
@@ -198,6 +216,8 @@ support_check() ->
 		fun check_public_key/2
 	])),
 	Entries2 = [
+		{crypto_fallback_applied, Fallback},
+		{crypto_supports_generation, make_ref()},
 		{pbes2_count_maximum, PBES2CountMaximum},
 		{unsecured_signing, UnsecuredSigning}
 		| Entries1
@@ -205,6 +225,86 @@ support_check() ->
 	true = ets:delete_all_objects(?TAB),
 	true = ets:insert(?TAB, Entries2),
 	ok.
+
+%% @private
+update_crypto_supports_entries(Entries) ->
+	true = ets:delete(?TAB, crypto_supports_external),
+	true = ets:insert(?TAB, Entries),
+	true = ets:insert(?TAB, {crypto_supports_generation, make_ref()}),
+	ok.
+
+%% @private
+crypto_supports_snapshot() ->
+	%% A normal code load does not necessarily invoke code_change/3. An older
+	%% running server therefore needs its table migrated lazily on the first
+	%% capability read after this module is loaded. Reconcile direct application
+	%% environment changes as well, including a setter process that exited after
+	%% writing the environment but before calling config_change/0.
+	CurrentFallback = application:get_env(jose, crypto_fallback, false),
+	case {
+		ets:lookup(?TAB, crypto_supports_generation),
+		ets:lookup(?TAB, crypto_fallback_applied)
+	} of
+		{
+			[{crypto_supports_generation, _}],
+			[{crypto_fallback_applied, CurrentFallback}]
+		} ->
+			ok;
+		_ ->
+			support_check()
+	end,
+	#{
+		generation => ets:lookup_element(?TAB, crypto_supports_generation, 2),
+		crypto_fallback => ets:lookup_element(?TAB, crypto_fallback_applied, 2),
+		ciphers => ets:select(?TAB, [{
+			{{cipher, '$1'}, {'$2', '_'}},
+			[{'=/=', '$2', jose_jwa_unsupported}],
+			['$1']
+		}]),
+		rsa_crypt => ets:select(?TAB, [{
+			{{rsa_crypt, '$1'}, {'$2', '_'}},
+			[{'=/=', '$2', jose_jwa_unsupported}],
+			['$1']
+		}]),
+		rsa_sign => ets:select(?TAB, [{
+			{{rsa_sign, '$1'}, {'$2', '_'}},
+			[{'=/=', '$2', jose_jwa_unsupported}],
+			['$1']
+		}]),
+		chacha20_poly1305_module => ets:lookup_element(?TAB, chacha20_poly1305_module, 2),
+		sha3_module => ets:lookup_element(?TAB, sha3_module, 2),
+		curve25519_module => ets:lookup_element(?TAB, curve25519_module, 2),
+		curve448_module => ets:lookup_element(?TAB, curve448_module, 2),
+		crypto_supports_external => ets:lookup(?TAB, crypto_supports_external)
+	}.
+
+%% @private
+cache_crypto_supports_internal(Generation, CacheKey, ExternalHashs, ExternalPublicKeys) ->
+	AppliedFallback = ets:lookup(?TAB, crypto_fallback_applied),
+	CurrentFallback = application:get_env(jose, crypto_fallback, false),
+	case {
+		ets:lookup(?TAB, crypto_supports_generation),
+		AppliedFallback
+	} of
+		{
+			[{crypto_supports_generation, Generation}],
+			[{crypto_fallback_applied, CurrentFallback}]
+		} ->
+			case ets:lookup(?TAB, crypto_supports_external) of
+				[{crypto_supports_external, CacheKey, CachedHashs, CachedPublicKeys}] ->
+					{ok, CachedHashs, CachedPublicKeys};
+				_ ->
+					true = ets:insert(?TAB, {
+						crypto_supports_external,
+						CacheKey,
+						ExternalHashs,
+						ExternalPublicKeys
+					}),
+					{ok, ExternalHashs, ExternalPublicKeys}
+			end;
+		_ ->
+			stale
+	end.
 
 %%%-------------------------------------------------------------------
 %%% Internal check functions
@@ -362,14 +462,14 @@ check_curve25519_module_does_it_work(Module) ->
 	GeneratedPK = Module:eddsa_secret_to_public(GeneratedSecret),
 	%% RFC 8032, section 7.1, blank-message Ed25519 test vector.
 	BlankSecret = base64:decode(<<
-		"nWGyPkrYNjJyl6j2RX9R71uEJfnCY1qWb0H8Qs+c9vA="
+		"nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A="
 	>>),
 	BlankPK = base64:decode(<<
-		"11qYAYdk9JMCdjR2QYEE8yL4h9tYNaG7N+aF6R1YlkI="
+		"11qYAYKxCrfVS/7TyWQHOg7hcvPapiMlrwIaaPcHURo="
 	>>),
 	BlankSignature = base64:decode(<<
-		"5Vb7cXgEcj7uHLiRPB8YPhAsgubLhxy9Hh2j9xG5VZlM9gJ3fxQZE2zBvmNsM5ELaXaBKqYcptLW"
-		"sI6N9gXjAA=="
+		"5VZDAMNgrHKQhuLMgG6CioSHfx645dl02HPgZSJJAVVfuIIVkKM7rMYeOXAc+bRr0lv18FlbviRl"
+		"UUFDjnoQCw=="
 	>>),
 	true = check_ed25519_vector(Module, BlankSecret, BlankPK, <<>>, BlankSignature),
 	%% RFC 8032, section 7.1, one-octet Ed25519 test vector.

--- a/src/jose_server.erl
+++ b/src/jose_server.erl
@@ -110,14 +110,17 @@ handle_call({chacha20_poly1305_module, M}, _From, State) ->
 	ChaCha20Poly1305Module = check_chacha20_poly1305_module(M),
 	Entries = lists:flatten(check_crypto(?CRYPTO_FALLBACK, [{chacha20_poly1305_module, ChaCha20Poly1305Module}])),
 	_ = ets:select_delete(?TAB, [{{{cipher, '_'}, '_'}, [], [true]}]),
+	true = ets:delete(?TAB, crypto_supports_external),
 	true = ets:insert(?TAB, Entries),
 	{reply, ok, State};
 handle_call({curve25519_module, M}, _From, State) ->
 	Curve25519Module = check_curve25519_module(M),
+	true = ets:delete(?TAB, crypto_supports_external),
 	true = ets:insert(?TAB, {curve25519_module, Curve25519Module}),
 	{reply, ok, State};
 handle_call({curve448_module, M}, _From, State) ->
 	Curve448Module = check_curve448_module(M),
+	true = ets:delete(?TAB, crypto_supports_external),
 	true = ets:insert(?TAB, {curve448_module, Curve448Module}),
 	{reply, ok, State};
 handle_call({json_module, M}, _From, State) ->
@@ -129,6 +132,7 @@ handle_call({pbes2_count_maximum, PBES2CountMaximum}, _From, State) when is_inte
 	{reply, ok, State};
 handle_call({sha3_module, M}, _From, State) ->
 	SHA3Module = check_sha3_module(M),
+	true = ets:delete(?TAB, crypto_supports_external),
 	true = ets:insert(?TAB, {sha3_module, SHA3Module}),
 	{reply, ok, State};
 handle_call({unsecured_signing, UnsecuredSigning}, _From, State) when is_boolean(UnsecuredSigning) ->
@@ -336,9 +340,8 @@ check_curve25519_modules(Fallback, [Module | Modules]) ->
 	case code:ensure_loaded(Module) of
 		{module, Module} ->
 			_ = application:ensure_all_started(Module),
-			RealFallback = jose_jwa_curve25519,
 			RealModule = check_curve25519_module(Module),
-			try check_curve25519_module_does_it_work(RealFallback, RealModule) of
+			try check_curve25519_module_does_it_work(RealModule) of
 				true ->
 					RealModule;
 				false ->
@@ -354,26 +357,41 @@ check_curve25519_modules(Fallback, []) ->
 	Fallback.
 
 %% @private
-check_curve25519_module_does_it_work(Fallback, Module) ->
-	{PK, SK = <<Secret:32/binary, _:32/binary>>} = Module:eddsa_keypair(),
+check_curve25519_module_does_it_work(Module) ->
+	{GeneratedPK, <<GeneratedSecret:32/binary, GeneratedPK:32/binary>>} = Module:eddsa_keypair(),
+	GeneratedPK = Module:eddsa_secret_to_public(GeneratedSecret),
+	%% RFC 8032, section 7.1, blank-message Ed25519 test vector.
+	BlankSecret = base64:decode(<<
+		"nWGyPkrYNjJyl6j2RX9R71uEJfnCY1qWb0H8Qs+c9vA="
+	>>),
+	BlankPK = base64:decode(<<
+		"11qYAYdk9JMCdjR2QYEE8yL4h9tYNaG7N+aF6R1YlkI="
+	>>),
+	BlankSignature = base64:decode(<<
+		"5Vb7cXgEcj7uHLiRPB8YPhAsgubLhxy9Hh2j9xG5VZlM9gJ3fxQZE2zBvmNsM5ELaXaBKqYcptLW"
+		"sI6N9gXjAA=="
+	>>),
+	true = check_ed25519_vector(Module, BlankSecret, BlankPK, <<>>, BlankSignature),
+	%% RFC 8032, section 7.1, one-octet Ed25519 test vector.
+	NonemptySecret = base64:decode(<<
+		"TM0Imyj/ltqdtsNG7BFOD1uKMZ81q6Yk2oz27U+4pvs="
+	>>),
+	NonemptyPK = base64:decode(<<
+		"PUAXw+hDiVqStwqnTRt+vJyYLM8uxJaMwM1V8Sr0Zgw="
+	>>),
+	NonemptySignature = base64:decode(<<
+		"kqAJqfDUyrhyDoILX2QlQKKye1QWUD+Ps3YiI+vbadoIWsHkPhWZbkWPNhPQ8R2MOHsurrQwKu6w"
+		"DSkWErsMAA=="
+	>>),
+	true = check_ed25519_vector(Module, NonemptySecret, NonemptyPK, <<16#72>>, NonemptySignature),
+	true.
+
+%% @private
+check_ed25519_vector(Module, Secret, PK, Message, Signature) ->
 	{PK, SK} = Module:eddsa_keypair(Secret),
 	PK = Module:eddsa_secret_to_public(Secret),
-	Message = crypto:strong_rand_bytes(16),
 	Signature = Module:ed25519_sign(Message, SK),
-	true = Module:ed25519_verify(Signature, Message, PK),
-	true = Fallback:ed25519_verify(Signature, Message, PK),
-	%% NOTE: Ed25519ctx and Ed25519ph are lower priority, no need to check for now.
-	% Ctx = <<"ctx">>,
-	% CtxSignature = Module:ed25519ctx_sign(Message, SK, Ctx),
-	% true = Module:ed25519ctx_verify(CtxSignature, Message, PK, Ctx),
-	% true = Fallback:ed25519ctx_verify(CtxSignature, Message, PK, Ctx),
-	% PHSignature = Module:ed25519ph_sign(Message, SK),
-	% true = Module:ed25519ph_verify(PHSignature, Message, PK),
-	% true = Fallback:ed25519ph_verify(PHSignature, Message, PK),
-	% CtxPHSignature = Module:ed25519ph_sign(Message, SK, Ctx),
-	% true = Module:ed25519ph_verify(CtxPHSignature, Message, PK, Ctx),
-	% true = Fallback:ed25519ph_verify(CtxPHSignature, Message, PK, Ctx),
-	true.
+	true = Module:ed25519_verify(Signature, Message, PK).
 
 %% @private
 check_curve448(false, Entries) ->
@@ -430,17 +448,32 @@ check_curve448_module_does_it_work(Module) ->
 	{GeneratedPK, <<GeneratedSecret:57/binary, GeneratedPK:57/binary>>} = Module:eddsa_keypair(),
 	GeneratedPK = Module:eddsa_secret_to_public(GeneratedSecret),
 	%% RFC 8032, section 7.4, blank-message Ed448 test vector.
-	Secret = base64:decode(<<
+	BlankSecret = base64:decode(<<
 		"bIKlYsuAjRDWMr6JyFE+v2ySnzTd+oyfY8mWDvbjSKNSjIo/zC8ETjmj/FuUSS+PAy51SaIAmPlb"
 	>>),
-	PK = base64:decode(<<
+	BlankPK = base64:decode(<<
 		"X9dEm1m0Yf0s54fsYWrUah2hNCSFpw4fig6nXYDpZ3jt8SR2m0bHBhvWeD3x5Q9s0foavq/oJWGA"
 	>>),
-	Signature = base64:decode(<<
+	BlankSignature = base64:decode(<<
 		"Uzo39rvkVyUfAjwNiPl2ri37UEqEPjTSB0/YI9QaWR8rIz8DT2KCgfL9eiLd1H14KMWb0KIb/TmA/"
 		"w0gKNSxip32PgBsXRwtNFuSXY3AC0EEhS25msXHzdqFMKEToPTbthFJ8FpzYyaMcdlYCP8uZSYA"
 	>>),
-	Message = <<>>,
+	true = check_ed448_vector(Module, BlankSecret, BlankPK, <<>>, BlankSignature),
+	%% RFC 8032, section 7.4, one-octet Ed448 test vector.
+	NonemptySecret = base64:decode(<<
+		"xOqwXTVwB8Yy89u0hImSTVUrCP4MNToNSh8ArNosRjr76mfF6NKHfF47w5emWZSe+AIelU4KEidO"
+	>>),
+	NonemptyPK = base64:decode(<<
+		"Q7oo9DDN/0Vq5TFUX37NCsg0pV2TWMA3K/oMbGeYwIZq6gHrAHQoArhDjqTLghacI1FgYntMOpSA"
+	>>),
+	NonemptySignature = base64:decode(<<
+		"Jrj5Fye9Yol68V5B60PDd++5xhDUjyM1ywvQCHgQ9DUlQbFDxLmBt+GPYt6MzfYz/BvwN6t813mA"
+		"Xg28wKrhy87hr7LgJ982vATc7L8VQzbBnwr34KZHKQXnmfGVPSoP8zSKshqkra/R0jREHPgHwDoA"
+	>>),
+	true = check_ed448_vector(Module, NonemptySecret, NonemptyPK, <<16#03>>, NonemptySignature).
+
+%% @private
+check_ed448_vector(Module, Secret, PK, Message, Signature) ->
 	{PK, SK} = Module:eddsa_keypair(Secret),
 	PK = Module:eddsa_secret_to_public(Secret),
 	Signature = Module:ed448_sign(Message, SK),

--- a/src/jwa/jose_jwa.erl
+++ b/src/jwa/jose_jwa.erl
@@ -190,10 +190,10 @@ crypto_supports() ->
 		{shake256, fun() -> jose_sha3:shake256(<<>>, 0) end}
 	]),
 	ExternalPublicKeys = external_checks([
-		{ed25519, fun jose_curve25519:eddsa_keypair/0},
-		{ed25519ph, fun jose_curve25519:eddsa_keypair/0},
-		{ed448, fun jose_curve448:eddsa_keypair/0},
-		{ed448ph, fun jose_curve448:eddsa_keypair/0},
+		{ed25519, fun() -> check_eddsa(jose_curve25519, ed25519_sign, ed25519_verify) end},
+		{ed25519ph, fun() -> check_eddsa(jose_curve25519, ed25519ph_sign, ed25519ph_verify) end},
+		{ed448, fun() -> check_eddsa(jose_curve448, ed448_sign, ed448_verify) end},
+		{ed448ph, fun() -> check_eddsa(jose_curve448, ed448ph_sign, ed448ph_verify) end},
 		{x25519, fun jose_curve25519:x25519_keypair/0},
 		{x448, fun jose_curve448:x448_keypair/0}
 	]),
@@ -389,6 +389,14 @@ unsecured_signing(Boolean) when is_boolean(Boolean) ->
 %%%-------------------------------------------------------------------
 %%% Internal functions
 %%%-------------------------------------------------------------------
+
+%% @private
+check_eddsa(Module, Sign, Verify) ->
+	{PK, SK} = Module:eddsa_keypair(),
+	Message = <<"jose_jwa:crypto_supports/0">>,
+	Signature = erlang:apply(Module, Sign, [Message, SK]),
+	true = erlang:apply(Module, Verify, [Signature, Message, PK]),
+	true.
 
 %% @private
 constant_time_compare(<< AH, AT/binary >>, << BH, BT/binary >>, R) ->

--- a/src/jwa/jose_jwa.erl
+++ b/src/jwa/jose_jwa.erl
@@ -38,8 +38,12 @@
 -export([supports/0]).
 -export([unsecured_signing/0]).
 -export([unsecured_signing/1]).
+%% Private API
+-export([crypto_supports_internal/0]).
+-export([crypto_supports_internal/1]).
 
 -define(TAB, ?MODULE).
+-define(CRYPTO_SUPPORTS_VERSION, eddsa_kat_v1).
 
 -define(MAYBE_START_JOSE(F), try
 	F
@@ -170,6 +174,15 @@ crypto_fallback(Boolean) when is_boolean(Boolean) ->
 	?MAYBE_START_JOSE(jose_server:config_change()).
 
 crypto_supports() ->
+	%% During a rolling code upgrade jose_jwa may be loaded before jose_server.
+	%% Keep the old direct path available until the serializing API is loaded.
+	case erlang:function_exported(jose_server, crypto_supports, 0) of
+		true -> ?MAYBE_START_JOSE(jose_server:crypto_supports());
+		false -> crypto_supports_internal()
+	end.
+
+%% @private
+crypto_supports_internal() ->
 	Ciphers = ?MAYBE_START_JOSE(ets:select(?TAB, [{
 		{{cipher, '$1'}, {'$2', '_'}},
 		[{'=/=', '$2', 'jose_jwa_unsupported'}],
@@ -185,7 +198,26 @@ crypto_supports() ->
 		[{'=/=', '$2', 'jose_jwa_unsupported'}],
 		['$1']
 	}])),
-	{ExternalHashs, ExternalPublicKeys} = external_supports(),
+	{ExternalHashs, ExternalPublicKeys} = external_supports_legacy(),
+	crypto_supports_result(Ciphers, RSACrypt, RSASign, ExternalHashs, ExternalPublicKeys).
+
+%% @private
+crypto_supports_internal(Snapshot) ->
+	case external_supports(Snapshot) of
+		stale ->
+			jose_server:crypto_supports();
+		{ExternalHashs, ExternalPublicKeys} ->
+			crypto_supports_result(
+				maps:get(ciphers, Snapshot),
+				maps:get(rsa_crypt, Snapshot),
+				maps:get(rsa_sign, Snapshot),
+				ExternalHashs,
+				ExternalPublicKeys
+			)
+	end.
+
+%% @private
+crypto_supports_result(Ciphers, RSACrypt, RSASign, ExternalHashs, ExternalPublicKeys) ->
 	Supports = crypto:supports(),
 	RecommendedHashs = [md5, poly1305, sha, sha256, sha384, sha512, shake256],
 	Hashs = RecommendedHashs -- ((RecommendedHashs -- proplists:get_value(hashs, Supports)) -- ExternalHashs),
@@ -410,35 +442,159 @@ external_checks([], Acc) ->
 	lists:reverse(Acc).
 
 %% @private
-external_supports() ->
-	%% The dispatch modules and fallback setting cover every operation below.
-	%% Runtime setters either change this key or explicitly clear the entry.
-	CacheKey = {
+external_supports(Snapshot) ->
+	CacheKey = external_supports_cache_key(
+		maps:get(crypto_fallback, Snapshot),
+		maps:get(chacha20_poly1305_module, Snapshot),
+		maps:get(sha3_module, Snapshot),
+		maps:get(curve25519_module, Snapshot),
+		maps:get(curve448_module, Snapshot)
+	),
+	case maps:get(crypto_supports_external, Snapshot) of
+		[{crypto_supports_external, CacheKey, ExternalHashs, ExternalPublicKeys}] ->
+			{ExternalHashs, ExternalPublicKeys};
+		_ ->
+			{ExternalHashs, ExternalPublicKeys} = check_external_supports(),
+			case CacheKey =:= external_supports_cache_key(
+				maps:get(crypto_fallback, Snapshot),
+				maps:get(chacha20_poly1305_module, Snapshot),
+				maps:get(sha3_module, Snapshot),
+				maps:get(curve25519_module, Snapshot),
+				maps:get(curve448_module, Snapshot)
+			) of
+				true ->
+					case jose_server:cache_crypto_supports(
+						maps:get(generation, Snapshot),
+						CacheKey,
+						ExternalHashs,
+						ExternalPublicKeys
+					) of
+						{ok, CachedHashs, CachedPublicKeys} ->
+							{CachedHashs, CachedPublicKeys};
+						stale ->
+							stale
+					end;
+				false ->
+					stale
+			end
+	end.
+
+%% @private
+external_supports_legacy() ->
+	CacheKey = external_supports_cache_key(
 		crypto_fallback(),
 		ets:lookup_element(?TAB, chacha20_poly1305_module, 2),
 		ets:lookup_element(?TAB, sha3_module, 2),
 		ets:lookup_element(?TAB, curve25519_module, 2),
 		ets:lookup_element(?TAB, curve448_module, 2)
-	},
+	),
 	case ets:lookup(?TAB, crypto_supports_external) of
 		[{crypto_supports_external, CacheKey, ExternalHashs, ExternalPublicKeys}] ->
 			{ExternalHashs, ExternalPublicKeys};
 		_ ->
-			ExternalHashs = external_checks([
-				{poly1305, fun() -> jose_chacha20_poly1305:authenticate(<<>>, <<0:256>>, <<0:96>>) end},
-				{shake256, fun() -> jose_sha3:shake256(<<>>, 0) end}
-			]),
-			ExternalPublicKeys = external_checks([
-				{ed25519, fun() -> check_eddsa(jose_curve25519, ed25519_sign, ed25519_verify) end},
-				{ed25519ph, fun() -> check_eddsa(jose_curve25519, ed25519ph_sign, ed25519ph_verify) end},
-				{ed448, fun() -> check_eddsa(jose_curve448, ed448_sign, ed448_verify) end},
-				{ed448ph, fun() -> check_eddsa(jose_curve448, ed448ph_sign, ed448ph_verify) end},
-				{x25519, fun jose_curve25519:x25519_keypair/0},
-				{x448, fun jose_curve448:x448_keypair/0}
-			]),
-			true = ets:insert(?TAB, {crypto_supports_external, CacheKey, ExternalHashs, ExternalPublicKeys}),
-			{ExternalHashs, ExternalPublicKeys}
+			check_external_supports()
 	end.
+
+%% @private
+external_supports_cache_key(Fallback, ChaCha20Poly1305Module, SHA3Module, Curve25519Module, Curve448Module) ->
+	{
+		?CRYPTO_SUPPORTS_VERSION,
+		Fallback,
+		ChaCha20Poly1305Module,
+		SHA3Module,
+		Curve25519Module,
+		Curve448Module,
+		external_supports_runtime_fingerprint([
+			ChaCha20Poly1305Module,
+			SHA3Module,
+			Curve25519Module,
+			Curve448Module
+		])
+	}.
+
+%% @private
+external_supports_runtime_fingerprint(Modules) ->
+	TransitiveModules = lists:append([external_supports_adapter_dependencies(Module) || Module <- Modules]),
+	{
+		crypto_fips_state(),
+		[{Module, module_fingerprint(Module)} || Module <- lists:usort([
+			crypto,
+			jose_chacha20_poly1305,
+			jose_curve25519,
+			jose_curve25519_fallback,
+			jose_curve448,
+			jose_curve448_fallback,
+			jose_jwa_curve25519,
+			jose_jwa_curve448,
+			jose_jwa_chacha20,
+			jose_jwa_ed25519,
+			jose_jwa_ed448,
+			jose_jwa_math,
+			jose_jwa_poly1305,
+			jose_jwa_sha3,
+			jose_jwa_x25519,
+			jose_jwa_x448,
+			jose_sha3
+			| Modules ++ TransitiveModules
+		])]
+	}.
+
+%% @private
+external_supports_adapter_dependencies(jose_chacha20_poly1305_libsodium) ->
+	[
+		libsodium_crypto_aead_chacha20poly1305,
+		libsodium_crypto_onetimeauth_poly1305,
+		libsodium_crypto_stream_chacha20
+	];
+external_supports_adapter_dependencies(jose_curve25519_libdecaf) ->
+	[libdecaf_curve25519];
+external_supports_adapter_dependencies(jose_curve25519_libsodium) ->
+	[
+		libsodium_crypto_box_curve25519xchacha20poly1305,
+		libsodium_crypto_scalarmult_curve25519,
+		libsodium_crypto_sign_ed25519,
+		libsodium_crypto_sign_ed25519ph
+	];
+external_supports_adapter_dependencies(jose_curve448_libdecaf) ->
+	[libdecaf_curve448];
+external_supports_adapter_dependencies(jose_sha3_keccakf1600_driver) ->
+	[keccakf1600_fips202];
+external_supports_adapter_dependencies(jose_sha3_keccakf1600_nif) ->
+	[keccakf1600];
+external_supports_adapter_dependencies(jose_sha3_libdecaf) ->
+	[libdecaf_sha3];
+external_supports_adapter_dependencies(_Module) ->
+	[].
+
+%% @private
+crypto_fips_state() ->
+	try crypto:info_fips()
+	catch
+		error:undef -> unsupported
+	end.
+
+%% @private
+module_fingerprint(Module) ->
+	try Module:module_info(md5)
+	catch
+		_:_ -> unavailable
+	end.
+
+%% @private
+check_external_supports() ->
+	ExternalHashs = external_checks([
+		{poly1305, fun() -> jose_chacha20_poly1305:authenticate(<<>>, <<0:256>>, <<0:96>>) end},
+		{shake256, fun() -> jose_sha3:shake256(<<>>, 0) end}
+	]),
+	ExternalPublicKeys = external_checks([
+		{ed25519, fun() -> check_eddsa(jose_curve25519, ed25519_sign, ed25519_verify) end},
+		{ed25519ph, fun() -> check_eddsa(jose_curve25519, ed25519ph_sign, ed25519ph_verify) end},
+		{ed448, fun() -> check_eddsa(jose_curve448, ed448_sign, ed448_verify) end},
+		{ed448ph, fun() -> check_eddsa(jose_curve448, ed448ph_sign, ed448ph_verify) end},
+		{x25519, fun jose_curve25519:x25519_keypair/0},
+		{x448, fun jose_curve448:x448_keypair/0}
+	]),
+	{ExternalHashs, ExternalPublicKeys}.
 
 %% @private
 rsa_crypt(Algorithm) ->

--- a/src/jwa/jose_jwa.erl
+++ b/src/jwa/jose_jwa.erl
@@ -185,18 +185,7 @@ crypto_supports() ->
 		[{'=/=', '$2', 'jose_jwa_unsupported'}],
 		['$1']
 	}])),
-	ExternalHashs = external_checks([
-		{poly1305, fun() -> jose_chacha20_poly1305:authenticate(<<>>, <<0:256>>, <<0:96>>) end},
-		{shake256, fun() -> jose_sha3:shake256(<<>>, 0) end}
-	]),
-	ExternalPublicKeys = external_checks([
-		{ed25519, fun() -> check_eddsa(jose_curve25519, ed25519_sign, ed25519_verify) end},
-		{ed25519ph, fun() -> check_eddsa(jose_curve25519, ed25519ph_sign, ed25519ph_verify) end},
-		{ed448, fun() -> check_eddsa(jose_curve448, ed448_sign, ed448_verify) end},
-		{ed448ph, fun() -> check_eddsa(jose_curve448, ed448ph_sign, ed448ph_verify) end},
-		{x25519, fun jose_curve25519:x25519_keypair/0},
-		{x448, fun jose_curve448:x448_keypair/0}
-	]),
+	{ExternalHashs, ExternalPublicKeys} = external_supports(),
 	Supports = crypto:supports(),
 	RecommendedHashs = [md5, poly1305, sha, sha256, sha384, sha512, shake256],
 	Hashs = RecommendedHashs -- ((RecommendedHashs -- proplists:get_value(hashs, Supports)) -- ExternalHashs),
@@ -419,6 +408,37 @@ external_checks([{Key, Check} | Checks], Acc) ->
 	end;
 external_checks([], Acc) ->
 	lists:reverse(Acc).
+
+%% @private
+external_supports() ->
+	%% The dispatch modules and fallback setting cover every operation below.
+	%% Runtime setters either change this key or explicitly clear the entry.
+	CacheKey = {
+		crypto_fallback(),
+		ets:lookup_element(?TAB, chacha20_poly1305_module, 2),
+		ets:lookup_element(?TAB, sha3_module, 2),
+		ets:lookup_element(?TAB, curve25519_module, 2),
+		ets:lookup_element(?TAB, curve448_module, 2)
+	},
+	case ets:lookup(?TAB, crypto_supports_external) of
+		[{crypto_supports_external, CacheKey, ExternalHashs, ExternalPublicKeys}] ->
+			{ExternalHashs, ExternalPublicKeys};
+		_ ->
+			ExternalHashs = external_checks([
+				{poly1305, fun() -> jose_chacha20_poly1305:authenticate(<<>>, <<0:256>>, <<0:96>>) end},
+				{shake256, fun() -> jose_sha3:shake256(<<>>, 0) end}
+			]),
+			ExternalPublicKeys = external_checks([
+				{ed25519, fun() -> check_eddsa(jose_curve25519, ed25519_sign, ed25519_verify) end},
+				{ed25519ph, fun() -> check_eddsa(jose_curve25519, ed25519ph_sign, ed25519ph_verify) end},
+				{ed448, fun() -> check_eddsa(jose_curve448, ed448_sign, ed448_verify) end},
+				{ed448ph, fun() -> check_eddsa(jose_curve448, ed448ph_sign, ed448ph_verify) end},
+				{x25519, fun jose_curve25519:x25519_keypair/0},
+				{x448, fun jose_curve448:x448_keypair/0}
+			]),
+			true = ets:insert(?TAB, {crypto_supports_external, CacheKey, ExternalHashs, ExternalPublicKeys}),
+			{ExternalHashs, ExternalPublicKeys}
+	end.
 
 %% @private
 rsa_crypt(Algorithm) ->

--- a/test/jose_server_test.exs
+++ b/test/jose_server_test.exs
@@ -1,0 +1,65 @@
+defmodule JOSEServerTest do
+  use ExUnit.Case, async: false
+
+  test "selects native Ed448 without crypto fallback or optional dependencies" do
+    if native_ed448_supported?() do
+      ebin = Application.app_dir(:jose, "ebin")
+
+      expression = """
+      ok = application:load({application, jose, [
+        {description, "JOSE isolated native Ed448 test"},
+        {vsn, "test"},
+        {mod, {jose_app, []}},
+        {registered, []},
+        {applications, [kernel, stdlib, crypto, asn1, public_key]},
+        {modules, []}
+      ]}),
+      ok = application:set_env(jose, crypto_fallback, false),
+      {ok, _} = application:ensure_all_started(jose),
+      jose_curve448_crypto = jose:curve448_module(),
+      jose_sha3_unsupported = jose:sha3_module(),
+      {PublicKey, SecretKey} = jose_curve448:eddsa_keypair(),
+      Message = <<\"native-ed448\">>,
+      Signature = jose_curve448:ed448_sign(Message, SecretKey),
+      true = jose_curve448:ed448_verify(Signature, Message, PublicKey),
+      PublicKeys = proplists:get_value(public_keys, jose_jwa:crypto_supports()),
+      true = lists:member(ed448, PublicKeys),
+      false = lists:member(ed448ph, PublicKeys),
+      false = lists:member(ed25519ph, PublicKeys),
+      ok = jose:crypto_fallback(true),
+      FallbackPublicKeys = proplists:get_value(public_keys, jose_jwa:crypto_supports()),
+      true = lists:member(ed448ph, FallbackPublicKeys),
+      true = lists:member(ed25519ph, FallbackPublicKeys),
+      halt(0).
+      """
+
+      {output, status} =
+        System.cmd(
+          System.find_executable("erl"),
+          [
+            "-noshell",
+            "-noinput",
+            "-pa",
+            ebin,
+            "-eval",
+            expression
+          ],
+          env: [{"ERL_LIBS", nil}],
+          stderr_to_stdout: true
+        )
+
+      assert status == 0, output
+    end
+  end
+
+  defp native_ed448_supported? do
+    {public_key, private_key} = :crypto.generate_key(:eddsa, :ed448)
+    message = "native-ed448-capability-check"
+    signature = :crypto.sign(:eddsa, :none, message, [private_key, :ed448])
+    :crypto.verify(:eddsa, :none, message, signature, [public_key, :ed448])
+  rescue
+    _ -> false
+  catch
+    _, _ -> false
+  end
+end

--- a/test/jose_server_test.exs
+++ b/test/jose_server_test.exs
@@ -1,65 +1,105 @@
 defmodule JOSEServerTest do
   use ExUnit.Case, async: false
 
-  test "selects native Ed448 without crypto fallback or optional dependencies" do
-    if native_ed448_supported?() do
-      ebin = Application.app_dir(:jose, "ebin")
+  @native_ed448_support (fn ->
+                           if :ed448 in Keyword.get(:crypto.supports(), :curves, []) do
+                             try do
+                               {public_key, private_key} = :crypto.generate_key(:eddsa, :ed448)
+                               message = "native-ed448-capability-check"
+                               signature = :crypto.sign(:eddsa, :none, message, [private_key, :ed448])
 
-      expression = """
-      ok = application:load({application, jose, [
-        {description, "JOSE isolated native Ed448 test"},
-        {vsn, "test"},
-        {mod, {jose_app, []}},
-        {registered, []},
-        {applications, [kernel, stdlib, crypto, asn1, public_key]},
-        {modules, []}
-      ]}),
-      ok = application:set_env(jose, crypto_fallback, false),
-      {ok, _} = application:ensure_all_started(jose),
-      jose_curve448_crypto = jose:curve448_module(),
-      jose_sha3_unsupported = jose:sha3_module(),
-      {PublicKey, SecretKey} = jose_curve448:eddsa_keypair(),
-      Message = <<\"native-ed448\">>,
-      Signature = jose_curve448:ed448_sign(Message, SecretKey),
-      true = jose_curve448:ed448_verify(Signature, Message, PublicKey),
-      PublicKeys = proplists:get_value(public_keys, jose_jwa:crypto_supports()),
-      true = lists:member(ed448, PublicKeys),
-      false = lists:member(ed448ph, PublicKeys),
-      false = lists:member(ed25519ph, PublicKeys),
-      ok = jose:crypto_fallback(true),
-      FallbackPublicKeys = proplists:get_value(public_keys, jose_jwa:crypto_supports()),
-      true = lists:member(ed448ph, FallbackPublicKeys),
-      true = lists:member(ed25519ph, FallbackPublicKeys),
-      halt(0).
-      """
+                               if :crypto.verify(
+                                    :eddsa,
+                                    :none,
+                                    message,
+                                    signature,
+                                    [public_key, :ed448]
+                                  ) do
+                                 :supported
+                               else
+                                 {:error, "native Ed448 verification returned false"}
+                               end
+                             catch
+                               kind, reason -> {:error, Exception.format_banner(kind, reason)}
+                             end
+                           else
+                             {:skip, "OTP crypto does not advertise native Ed448 support"}
+                           end
+                         end).()
 
-      {output, status} =
-        System.cmd(
-          System.find_executable("erl"),
-          [
-            "-noshell",
-            "-noinput",
-            "-pa",
-            ebin,
-            "-eval",
-            expression
-          ],
-          env: [{"ERL_LIBS", nil}],
-          stderr_to_stdout: true
-        )
+  case @native_ed448_support do
+    :supported ->
+      test "selects native Ed448 without crypto fallback or optional dependencies" do
+        ebin = Application.app_dir(:jose, "ebin")
 
-      assert status == 0, output
-    end
-  end
+        expression = """
+        ok = application:load({application, jose, [
+          {description, "JOSE isolated native Ed448 test"},
+          {vsn, "test"},
+          {mod, {jose_app, []}},
+          {registered, []},
+          {applications, [kernel, stdlib, crypto, asn1, public_key]},
+          {modules, []}
+        ]}),
+        ok = application:set_env(jose, crypto_fallback, false),
+        {ok, _} = application:ensure_all_started(jose),
+        jose_curve448_crypto = jose:curve448_module(),
+        jose_sha3_unsupported = jose:sha3_module(),
+        {PublicKey, SecretKey} = jose_curve448:eddsa_keypair(),
+        Message = <<\"native-ed448\">>,
+        Signature = jose_curve448:ed448_sign(Message, SecretKey),
+        true = jose_curve448:ed448_verify(Signature, Message, PublicKey),
+        PublicKeys = proplists:get_value(public_keys, jose_jwa:crypto_supports()),
+        true = lists:member(ed448, PublicKeys),
+        false = lists:member(ed448ph, PublicKeys),
+        false = lists:member(ed25519ph, PublicKeys),
+        ok = jose:crypto_fallback(true),
+        FallbackPublicKeys = proplists:get_value(public_keys, jose_jwa:crypto_supports()),
+        true = lists:member(ed448ph, FallbackPublicKeys),
+        true = lists:member(ed25519ph, FallbackPublicKeys),
+        ok = jose:curve448_module(jose_curve448_unsupported),
+        UnsupportedPublicKeys = proplists:get_value(public_keys, jose_jwa:crypto_supports()),
+        false = lists:member(ed448, UnsupportedPublicKeys),
+        false = lists:member(ed448ph, UnsupportedPublicKeys),
+        ok = jose:curve448_module(crypto),
+        RestoredPublicKeys = proplists:get_value(public_keys, jose_jwa:crypto_supports()),
+        true = lists:member(ed448, RestoredPublicKeys),
+        true = lists:member(ed448ph, RestoredPublicKeys),
+        halt(0).
+        """
 
-  defp native_ed448_supported? do
-    {public_key, private_key} = :crypto.generate_key(:eddsa, :ed448)
-    message = "native-ed448-capability-check"
-    signature = :crypto.sign(:eddsa, :none, message, [private_key, :ed448])
-    :crypto.verify(:eddsa, :none, message, signature, [public_key, :ed448])
-  rescue
-    _ -> false
-  catch
-    _, _ -> false
+        {output, status} =
+          System.cmd(
+            System.find_executable("erl"),
+            [
+              "-noshell",
+              "-noinput",
+              "-pa",
+              ebin,
+              "-eval",
+              expression
+            ],
+            env: [
+              {"ERL_LIBS", nil},
+              {"ERL_FLAGS", nil},
+              {"ERL_AFLAGS", nil},
+              {"ERL_ZFLAGS", nil}
+            ],
+            stderr_to_stdout: true
+          )
+
+        assert status == 0, output
+      end
+
+    {:skip, reason} ->
+      @tag skip: reason
+      test "selects native Ed448 without crypto fallback or optional dependencies", do: :ok
+
+    {:error, reason} ->
+      @native_ed448_error reason
+
+      test "selects native Ed448 without crypto fallback or optional dependencies" do
+        flunk("OTP advertised native Ed448, but its operation probe failed: #{@native_ed448_error}")
+      end
   end
 end

--- a/test/jose_server_test.exs
+++ b/test/jose_server_test.exs
@@ -1,6 +1,262 @@
 defmodule JOSEServerTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureLog
+
+  defmodule BlockingCurve448 do
+    def eddsa_keypair do
+      maybe_block()
+      delegate(:eddsa_keypair, [])
+    end
+
+    def ed448_sign(message, secret_key), do: delegate(:ed448_sign, [message, secret_key])
+
+    def ed448_verify(signature, message, public_key),
+      do: delegate(:ed448_verify, [signature, message, public_key])
+
+    def ed448ph_sign(message, secret_key), do: delegate(:ed448ph_sign, [message, secret_key])
+
+    def ed448ph_verify(signature, message, public_key),
+      do: delegate(:ed448ph_verify, [signature, message, public_key])
+
+    def x448_keypair, do: delegate(:x448_keypair, [])
+
+    defp maybe_block do
+      case Application.get_env(:jose, :crypto_supports_test_block) do
+        {owner, reference} ->
+          Application.delete_env(:jose, :crypto_supports_test_block)
+          send(owner, {:crypto_supports_probe_blocked, self(), reference})
+
+          receive do
+            {^reference, :continue} -> :ok
+          after
+            5_000 -> raise "timed out waiting to release capability probe"
+          end
+
+        nil ->
+          :ok
+      end
+    end
+
+    defp delegate(function, arguments) do
+      module = Application.fetch_env!(:jose, :crypto_supports_test_curve448_delegate)
+      apply(module, function, arguments)
+    end
+  end
+
+  test "serializes complete capability reads with configuration changes" do
+    baseline = :jose_jwa.crypto_supports()
+    parent = self()
+
+    toggler =
+      Task.async(fn ->
+        send(parent, :ready)
+
+        receive do
+          :go -> Enum.each(1..100, fn _ -> assert :ok = :jose_server.config_change() end)
+        end
+      end)
+
+    readers =
+      for _ <- 1..4 do
+        Task.async(fn ->
+          send(parent, :ready)
+
+          receive do
+            :go -> Enum.each(1..250, fn _ -> assert :jose_jwa.crypto_supports() == baseline end)
+          end
+        end)
+      end
+
+    tasks = [toggler | readers]
+    Enum.each(tasks, fn _task -> assert_receive :ready, 5_000 end)
+    Enum.each(tasks, &send(&1.pid, :go))
+    Enum.each(tasks, &Task.await(&1, 60_000))
+  end
+
+  test "slow capability probes do not block configuration changes" do
+    original_module = :jose.curve448_module()
+    reference = make_ref()
+
+    Application.put_env(:jose, :crypto_supports_test_curve448_delegate, original_module)
+    Application.put_env(:jose, :crypto_supports_test_block, {self(), reference})
+    assert :ok = :jose.curve448_module(BlockingCurve448)
+
+    on_exit(fn ->
+      Application.delete_env(:jose, :crypto_supports_test_block)
+      Application.delete_env(:jose, :crypto_supports_test_curve448_delegate)
+      :ok = :jose.curve448_module(original_module)
+    end)
+
+    probe = Task.async(fn -> :jose_jwa.crypto_supports() end)
+
+    assert_receive {:crypto_supports_probe_blocked, probe_process, ^reference}, 5_000
+
+    setter = Task.async(fn -> :jose.curve448_module(original_module) end)
+    assert :ok = Task.await(setter, 1_000)
+
+    send(probe_process, {reference, :continue})
+    assert Task.await(probe, 10_000) == :jose_jwa.crypto_supports()
+  end
+
+  test "rejects a stale capability probe after the server restarts" do
+    original_module = :jose.curve448_module()
+    reference = make_ref()
+
+    Application.put_env(:jose, :crypto_supports_test_curve448_delegate, original_module)
+    Application.put_env(:jose, :crypto_supports_test_block, {self(), reference})
+    assert :ok = :jose.curve448_module(BlockingCurve448)
+
+    on_exit(fn ->
+      Application.delete_env(:jose, :crypto_supports_test_block)
+      Application.delete_env(:jose, :crypto_supports_test_curve448_delegate)
+      :ok = :jose.curve448_module(original_module)
+    end)
+
+    probe = Task.async(fn -> :jose_jwa.crypto_supports() end)
+
+    assert_receive {:crypto_supports_probe_blocked, probe_process, ^reference}, 5_000
+
+    old_server = Process.whereis(:jose_server)
+
+    capture_log(fn ->
+      Process.exit(old_server, :kill)
+      assert wait_for_new_server(old_server)
+    end)
+
+    send(probe_process, {reference, :continue})
+    assert Task.await(probe, 10_000) == :jose_jwa.crypto_supports()
+  end
+
+  test "lazily migrates a pre-generation capability cache" do
+    baseline = :jose_jwa.crypto_supports()
+
+    on_exit(fn -> :ok = :jose_server.config_change() end)
+
+    :ets.delete(:jose_jwa, :crypto_supports_generation)
+    :ets.delete(:jose_jwa, :crypto_fallback_applied)
+
+    :ets.insert(
+      :jose_jwa,
+      {:crypto_supports_external, {:old_probe, false}, [:stale_hash], [:stale_key]}
+    )
+
+    assert :jose_jwa.crypto_supports() == baseline
+
+    assert [{:crypto_supports_generation, generation}] =
+             :ets.lookup(:jose_jwa, :crypto_supports_generation)
+
+    assert is_reference(generation)
+    refute :stale_hash in Keyword.fetch!(baseline, :hashs)
+    refute :stale_key in Keyword.fetch!(baseline, :public_keys)
+  end
+
+  test "reconciles unapplied crypto fallback environment changes" do
+    original_fallback = :jose.crypto_fallback()
+    changed_fallback = not original_fallback
+    :jose_jwa.crypto_supports()
+
+    [{:crypto_supports_generation, original_generation}] =
+      :ets.lookup(:jose_jwa, :crypto_supports_generation)
+
+    on_exit(fn -> :ok = :jose.crypto_fallback(original_fallback) end)
+
+    Application.put_env(:jose, :crypto_fallback, changed_fallback)
+    assert is_list(:jose_jwa.crypto_supports())
+
+    assert [{:crypto_fallback_applied, ^changed_fallback}] =
+             :ets.lookup(:jose_jwa, :crypto_fallback_applied)
+
+    assert [{:crypto_supports_generation, changed_generation}] =
+             :ets.lookup(:jose_jwa, :crypto_supports_generation)
+
+    refute changed_generation == original_generation
+
+    Application.put_env(:jose, :crypto_fallback, original_fallback)
+    :ets.delete(:jose_jwa, :crypto_supports_external)
+
+    assert is_list(:jose_jwa.crypto_supports())
+
+    assert [{:crypto_fallback_applied, ^original_fallback}] =
+             :ets.lookup(:jose_jwa, :crypto_fallback_applied)
+  end
+
+  test "invalidates capability results when adapter code changes" do
+    original_module = :jose.sha3_module()
+    compiler_options = Code.compiler_options()
+
+    Code.compiler_options(ignore_module_conflict: true)
+
+    on_exit(fn ->
+      Code.compiler_options(compiler_options)
+      :ok = :jose.sha3_module(original_module)
+      :code.purge(JOSEServerMutableSHA3)
+      :code.delete(JOSEServerMutableSHA3)
+    end)
+
+    Code.compile_string("""
+    defmodule JOSEServerMutableSHA3 do
+      def shake256(_input, _output_byte_len), do: <<>>
+    end
+    """)
+
+    assert :ok = :jose.sha3_module(JOSEServerMutableSHA3)
+    :jose_jwa.crypto_supports()
+
+    assert [{:crypto_supports_external, first_key, first_hashs, _public_keys}] =
+             :ets.lookup(:jose_jwa, :crypto_supports_external)
+
+    assert :shake256 in first_hashs
+
+    Code.compile_string("""
+    defmodule JOSEServerMutableSHA3 do
+      def shake256(_input, _output_byte_len), do: raise("backend unavailable")
+    end
+    """)
+
+    :jose_jwa.crypto_supports()
+
+    assert [{:crypto_supports_external, second_key, second_hashs, _public_keys}] =
+             :ets.lookup(:jose_jwa, :crypto_supports_external)
+
+    refute first_key == second_key
+    refute :shake256 in second_hashs
+  end
+
+  test "invalidates capability results when transitive fallback code changes" do
+    {:jose_jwa_math, original_binary, original_path} = :code.get_object_code(:jose_jwa_math)
+    compiler_options = Code.compiler_options()
+
+    Code.compiler_options(ignore_module_conflict: true)
+
+    on_exit(fn ->
+      Code.compiler_options(compiler_options)
+
+      {:module, :jose_jwa_math} =
+        :code.load_binary(:jose_jwa_math, original_path, original_binary)
+
+      :jose_jwa.crypto_supports()
+    end)
+
+    :jose_jwa.crypto_supports()
+
+    assert [{:crypto_supports_external, first_key, _hashs, _public_keys}] =
+             :ets.lookup(:jose_jwa, :crypto_supports_external)
+
+    Code.compile_string("""
+    defmodule :jose_jwa_math do
+      def replacement_probe, do: :replacement
+    end
+    """)
+
+    :jose_jwa.crypto_supports()
+
+    assert [{:crypto_supports_external, second_key, _hashs, _public_keys}] =
+             :ets.lookup(:jose_jwa, :crypto_supports_external)
+
+    refute first_key == second_key
+  end
+
   @native_ed448_support (fn ->
                            if :ed448 in Keyword.get(:crypto.supports(), :curves, []) do
                              try do
@@ -42,14 +298,47 @@ defmodule JOSEServerTest do
           {modules, []}
         ]}),
         ok = application:set_env(jose, crypto_fallback, false),
-        {ok, _} = application:ensure_all_started(jose),
+        WaitFor = fun
+          Wait([]) -> ok;
+          Wait([{Pid, Ref} | Rest]) ->
+            receive
+              {'DOWN', Ref, process, Pid, normal} -> Wait(Rest);
+              {'DOWN', Ref, process, Pid, Reason} -> erlang:error({worker_failed, Reason})
+            end
+        end,
+        Starter = spawn_monitor(fun() -> {ok, _} = application:ensure_all_started(jose) end),
+        Parent = self(),
+        StartupWorkers = [spawn_monitor(fun() ->
+          Supports = jose_jwa:crypto_supports(),
+          Parent ! {startup_supports, Supports}
+        end)
+          || _ <- lists:seq(1, 8)],
+        ok = WaitFor([Starter | StartupWorkers]),
+        CheckStartupSupports = fun
+          Check(0) -> ok;
+          Check(Remaining) ->
+            receive
+              {startup_supports, Supports} ->
+                StartupPublicKeys = proplists:get_value(public_keys, Supports),
+                true = lists:member(ed25519, StartupPublicKeys),
+                true = lists:member(ed448, StartupPublicKeys),
+                Check(Remaining - 1)
+            end
+        end,
+        ok = CheckStartupSupports(8),
+        jose_curve25519_crypto = jose:curve25519_module(),
         jose_curve448_crypto = jose:curve448_module(),
         jose_sha3_unsupported = jose:sha3_module(),
+        {PublicKey25519, SecretKey25519} = jose_curve25519:eddsa_keypair(),
+        Message25519 = <<\"native-ed25519\">>,
+        Signature25519 = jose_curve25519:ed25519_sign(Message25519, SecretKey25519),
+        true = jose_curve25519:ed25519_verify(Signature25519, Message25519, PublicKey25519),
         {PublicKey, SecretKey} = jose_curve448:eddsa_keypair(),
         Message = <<\"native-ed448\">>,
         Signature = jose_curve448:ed448_sign(Message, SecretKey),
         true = jose_curve448:ed448_verify(Signature, Message, PublicKey),
         PublicKeys = proplists:get_value(public_keys, jose_jwa:crypto_supports()),
+        true = lists:member(ed25519, PublicKeys),
         true = lists:member(ed448, PublicKeys),
         false = lists:member(ed448ph, PublicKeys),
         false = lists:member(ed25519ph, PublicKeys),
@@ -101,5 +390,24 @@ defmodule JOSEServerTest do
       test "selects native Ed448 without crypto fallback or optional dependencies" do
         flunk("OTP advertised native Ed448, but its operation probe failed: #{@native_ed448_error}")
       end
+  end
+
+  defp wait_for_new_server(old_server, attempts \\ 100)
+
+  defp wait_for_new_server(_old_server, 0), do: false
+
+  defp wait_for_new_server(old_server, attempts) do
+    case Process.whereis(:jose_server) do
+      nil ->
+        Process.sleep(10)
+        wait_for_new_server(old_server, attempts - 1)
+
+      ^old_server ->
+        Process.sleep(10)
+        wait_for_new_server(old_server, attempts - 1)
+
+      new_server ->
+        Process.alive?(new_server)
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Detect OTP's native Ed448 implementation without depending on the optional pure Erlang fallback.
- Validate Curve25519 and Curve448 adapters against fallback-independent RFC 8032 vectors.
- Report Ed25519, Ed25519ph, Ed448, and Ed448ph only after their actual sign and verify operations succeed.
- Make capability caching generation-safe across configuration changes, server restarts, FIPS transitions, and hot code loading.
- Document the native `crypto` adapters for both Curve25519 and Curve448.

## Details

The Curve448 startup probe previously asked `jose_jwa_curve448` to cross-verify a native signature. With `crypto_fallback: false`, that verifier has no SHAKE256 backend, so JOSE rejected a working `jose_curve448_crypto` adapter.

The startup probes now validate candidate adapters directly against RFC 8032 blank and non-empty known-answer vectors for Ed25519 and Ed448. Operational capability checks run outside `jose_server`, while short server-issued snapshots and conditional cache writes prevent partial or stale results without allowing a slow custom adapter to block configuration calls.

Cache generations use references to prevent ABA reuse across server restarts. Applied fallback state, native FIPS state, selected adapter code, and JOSE's transitive fallback modules participate in invalidation. Rolling code upgrades lazily migrate older cache tables.

## Verification

- OTP 27 full ExUnit suite: 23 tests, 0 failures.
- OTP 28 full ExUnit suite: 23 tests, 0 failures.
- OTP 29 production compilation, native Ed25519/Ed448 smoke tests, and concurrent capability stress.
- Both rolling module-load orders exercised against the 1.11.12 beams.
- Elixir formatting and diff checks.
- Two independent adversarial code reviews; all actionable P2/P3 findings incorporated.

Fixes #198
